### PR TITLE
support setting image pull policy

### DIFF
--- a/api/doris/v1/types.go
+++ b/api/doris/v1/types.go
@@ -129,6 +129,10 @@ type BaseSpec struct {
 	//Image for a doris cn deployment.
 	Image string `json:"image"`
 
+	// Image pull policy.
+	// More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use.
 	// More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod

--- a/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
+++ b/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
@@ -1131,6 +1131,9 @@ spec:
                   image:
                     description: Image for a doris cn deployment.
                     type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images'
+                    type: string
                   imagePullSecrets:
                     description: 'ImagePullSecrets is an optional list of references
                       to secrets in the same namespace to use for pulling any of the
@@ -2651,6 +2654,9 @@ spec:
                         type: array
                       image:
                         description: Image for a doris cn deployment.
+                        type: string
+                      imagePullPolicy:
+                        description: 'Image pull policy. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images'
                         type: string
                       imagePullSecrets:
                         description: 'ImagePullSecrets is an optional list of references
@@ -4884,6 +4890,9 @@ spec:
                   image:
                     description: Image for a doris cn deployment.
                     type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images'
+                    type: string
                   imagePullSecrets:
                     description: 'ImagePullSecrets is an optional list of references
                       to secrets in the same namespace to use for pulling any of the
@@ -6366,6 +6375,9 @@ spec:
                     type: array
                   image:
                     description: Image for a doris cn deployment.
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images'
                     type: string
                   imagePullSecrets:
                     description: 'ImagePullSecrets is an optional list of references

--- a/pkg/common/utils/resource/pod.go
+++ b/pkg/common/utils/resource/pod.go
@@ -203,7 +203,7 @@ func NewBaseMainContainer(dcr *v1.DorisCluster, config map[string]interface{}, c
 		Ports:           []corev1.ContainerPort{},
 		Env:             envs,
 		VolumeMounts:    volumeMounts,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: getImagePullPolicy(spec),
 		Resources:       spec.ResourceRequirements,
 	}
 
@@ -297,6 +297,14 @@ func buildVolumeMounts(spec v1.BaseSpec, componentType v1.ComponentType) []corev
 		volumeMounts = append(volumeMounts, volumeMount)
 	}
 	return volumeMounts
+}
+
+func getImagePullPolicy(spec v1.BaseSpec) corev1.PullPolicy {
+	imagePullPolicy := corev1.PullIfNotPresent
+	if spec.ImagePullPolicy != "" {
+		imagePullPolicy = corev1.PullPolicy(spec.ImagePullPolicy)
+	}
+	return imagePullPolicy
 }
 
 func getCommand(componentType v1.ComponentType) (commands []string, args []string) {


### PR DESCRIPTION
support setting image pull policy with `spec.imagePullPolicy`, more info: https://kubernetes.io/docs/concepts/containers/images/#updating-images

default pull policy is `PullIfNotPresent`

yaml example: 
```
apiVersion: doris.selectdb.com/v1
kind: DorisCluster
...
spec:
  feSpec:
  image: iregistry.baidu-int.com/doris-rdw/rdw_doris_fe:v1.0.5
  imagePullPolicy: Always
..
```