### PR TITLE
Add option to specify which namespace to reconcile objects for

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -22,6 +22,7 @@ import (
 	dorisv1 "github.com/selectdb/doris-operator/api/doris/v1"
 	"github.com/selectdb/doris-operator/pkg/controller"
 	"io"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -69,8 +70,10 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var namespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&namespace, "namespace", v12.NamespaceAll, "The namespace to watch for changes.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -93,6 +96,7 @@ func main() {
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
+		Namespace:              namespace,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "e1370669.selectdb.com",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily


### PR DESCRIPTION
Adds a runtime argument to specify which namespace to perform resource reconciliation for. This allows the operator to run multiple instances across different namespaces in a single cluster environment . The default is to watch all namespaces.