### PR TITLE
upgrade go version to 1.22.4 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 # Build the manager binary
-FROM golang:1.21.12 AS builder
+FROM golang:1.22.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Need to upgrade to 1.22.4, otherwise you will get the following error when running `make docker-build`
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/f527ac75-98d3-4cbe-95fd-524335d6efc1">
