### PR TITLE
Support Arrow Flight SQL Port in External Service

### DIFF
--- a/pkg/common/utils/resource/configmap.go
+++ b/pkg/common/utils/resource/configmap.go
@@ -55,6 +55,8 @@ const (
 	DefaultMsTokenKey = "http_token"
 )
 
+const ARROW_FLIGHT_SQL_PORT = "arrow_flight_sql_port"
+
 const BROKER_IPC_PORT = "broker_ipc_port"
 const GRACE_SHUTDOWN_WAIT_SECONDS = "grace_shutdown_wait_seconds"
 
@@ -75,6 +77,7 @@ var defMap = map[string]int32{
 	BRPC_PORT:              8060,
 	BROKER_IPC_PORT:        8000,
 	BRPC_LISTEN_PORT:       5000,
+	ARROW_FLIGHT_SQL_PORT:  9090,
 }
 
 // GetStartMode return fe host type, fqdn(host) or ip, from 'fe.conf' enable_fqdn_mode

--- a/pkg/common/utils/resource/configmap.go
+++ b/pkg/common/utils/resource/configmap.go
@@ -77,7 +77,7 @@ var defMap = map[string]int32{
 	BRPC_PORT:              8060,
 	BROKER_IPC_PORT:        8000,
 	BRPC_LISTEN_PORT:       5000,
-	ARROW_FLIGHT_SQL_PORT:  9090,
+	ARROW_FLIGHT_SQL_PORT:  -1,
 }
 
 // GetStartMode return fe host type, fqdn(host) or ip, from 'fe.conf' enable_fqdn_mode

--- a/pkg/common/utils/resource/service.go
+++ b/pkg/common/utils/resource/service.go
@@ -179,9 +179,13 @@ func getFeServicePorts(config map[string]interface{}) (ports []corev1.ServicePor
 		Port: queryPort, TargetPort: intstr.FromInt(int(queryPort)), Name: GetPortKey(QUERY_PORT),
 	}, corev1.ServicePort{
 		Port: editPort, TargetPort: intstr.FromInt(int(editPort)), Name: GetPortKey(EDIT_LOG_PORT),
-	}, corev1.ServicePort{
-		Port: arrowFlightPort, TargetPort: intstr.FromInt(int(arrowFlightPort)), Name: GetPortKey(ARROW_FLIGHT_SQL_PORT),
 	})
+
+	if arrowFlightPort != -1 {
+		ports = append(ports, corev1.ServicePort{
+			Port: arrowFlightPort, TargetPort: intstr.FromInt(int(arrowFlightPort)), Name: GetPortKey(ARROW_FLIGHT_SQL_PORT),
+		})
+	}
 
 	return
 }
@@ -201,9 +205,13 @@ func getBeServicePorts(config map[string]interface{}) (ports []corev1.ServicePor
 		Port: heartPort, TargetPort: intstr.FromInt(int(heartPort)), Name: GetPortKey(HEARTBEAT_SERVICE_PORT),
 	}, corev1.ServicePort{
 		Port: brpcPort, TargetPort: intstr.FromInt(int(brpcPort)), Name: GetPortKey(BRPC_PORT),
-	}, corev1.ServicePort{
-		Port: arrowFlightPort, TargetPort: intstr.FromInt(int(arrowFlightPort)), Name: GetPortKey(ARROW_FLIGHT_SQL_PORT),
 	})
+
+	if arrowFlightPort != -1 {
+		ports = append(ports, corev1.ServicePort{
+			Port: arrowFlightPort, TargetPort: intstr.FromInt(int(arrowFlightPort)), Name: GetPortKey(ARROW_FLIGHT_SQL_PORT),
+		})
+	}
 
 	return
 }

--- a/pkg/common/utils/resource/service.go
+++ b/pkg/common/utils/resource/service.go
@@ -170,6 +170,7 @@ func getFeServicePorts(config map[string]interface{}) (ports []corev1.ServicePor
 	rpcPort := GetPort(config, RPC_PORT)
 	queryPort := GetPort(config, QUERY_PORT)
 	editPort := GetPort(config, EDIT_LOG_PORT)
+	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
 	ports = append(ports, corev1.ServicePort{
 		Port: httpPort, TargetPort: intstr.FromInt(int(httpPort)), Name: GetPortKey(HTTP_PORT),
 	}, corev1.ServicePort{
@@ -177,7 +178,10 @@ func getFeServicePorts(config map[string]interface{}) (ports []corev1.ServicePor
 	}, corev1.ServicePort{
 		Port: queryPort, TargetPort: intstr.FromInt(int(queryPort)), Name: GetPortKey(QUERY_PORT),
 	}, corev1.ServicePort{
-		Port: editPort, TargetPort: intstr.FromInt(int(editPort)), Name: GetPortKey(EDIT_LOG_PORT)})
+		Port: editPort, TargetPort: intstr.FromInt(int(editPort)), Name: GetPortKey(EDIT_LOG_PORT),
+	}, corev1.ServicePort{
+		Port: arrowFlightPort, TargetPort: intstr.FromInt(int(arrowFlightPort)), Name: GetPortKey(ARROW_FLIGHT_SQL_PORT),
+	})
 
 	return
 }
@@ -187,6 +191,7 @@ func getBeServicePorts(config map[string]interface{}) (ports []corev1.ServicePor
 	webseverPort := GetPort(config, WEBSERVER_PORT)
 	heartPort := GetPort(config, HEARTBEAT_SERVICE_PORT)
 	brpcPort := GetPort(config, BRPC_PORT)
+	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
 
 	ports = append(ports, corev1.ServicePort{
 		Port: bePort, TargetPort: intstr.FromInt(int(bePort)), Name: GetPortKey(BE_PORT),
@@ -196,6 +201,8 @@ func getBeServicePorts(config map[string]interface{}) (ports []corev1.ServicePor
 		Port: heartPort, TargetPort: intstr.FromInt(int(heartPort)), Name: GetPortKey(HEARTBEAT_SERVICE_PORT),
 	}, corev1.ServicePort{
 		Port: brpcPort, TargetPort: intstr.FromInt(int(brpcPort)), Name: GetPortKey(BRPC_PORT),
+	}, corev1.ServicePort{
+		Port: arrowFlightPort, TargetPort: intstr.FromInt(int(arrowFlightPort)), Name: GetPortKey(ARROW_FLIGHT_SQL_PORT),
 	})
 
 	return
@@ -310,6 +317,8 @@ func GetPortKey(configKey string) string {
 		return strings.ReplaceAll(BROKER_IPC_PORT, "_", "-")
 	case BRPC_LISTEN_PORT:
 		return "brpc-port"
+	case ARROW_FLIGHT_SQL_PORT:
+		return "arrow-flight-port"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Port `9090` is the arrow flight sql port
```
feSpec:
    replicas: 1
    image: selectdb/doris.fe-ubuntu:2.1.5
    limits:
      cpu: 4
      memory: 8Gi
    requests:
      cpu: 4
      memory: 8Gi
    configMapInfo:
      configMapName: fe-configmap
      resolveKey: fe.conf
    service:
      type: NodePort
      servicePorts:
        - nodePort: 31007
          targetPort: 9090
beSpec:
    replicas: 1
    image: selectdb/doris.be-ubuntu:2.1.5
    limits:
      cpu: 4
      memory: 8Gi
    requests:
      cpu: 4
      memory: 8Gi
    configMapInfo:
      configMapName: be-configmap
      resolveKey: be.conf
    service:
      type: NodePort
      servicePorts:
        - nodePort: 31009
          targetPort: 9090
```