### PR TITLE
Expose Arrow Flight SQL ports as container ports in BEs and FEs #294

### DIFF
--- a/pkg/common/utils/resource/service.go
+++ b/pkg/common/utils/resource/service.go
@@ -278,7 +278,8 @@ func getFeContainerPorts(config map[string]interface{}) []corev1.ContainerPort {
 	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
 	if arrowFlightPort != -1 {
 		ports = append(ports, corev1.ContainerPort{
-			Name:          GetPortKey(ARROW_FLIGHT_SQL_PORT),
+			// GetPortKey(ARROW_FLIGHT_SQL_PORT) Hardcoding for now. In Kubernetes, container port names must be no more than 15 characters.
+			Name:          "arrow-flight",
 			ContainerPort: arrowFlightPort,
 			Protocol:      corev1.ProtocolTCP,
 		})
@@ -309,7 +310,8 @@ func getBeContainerPorts(config map[string]interface{}) []corev1.ContainerPort {
 	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
 	if arrowFlightPort != -1 {
 		ports = append(ports, corev1.ContainerPort{
-			Name:          GetPortKey(ARROW_FLIGHT_SQL_PORT),
+			// GetPortKey(ARROW_FLIGHT_SQL_PORT) Hardcoding for now. In Kubernetes, container port names must be no more than 15 characters.
+			Name:          "arrow-flight",
 			ContainerPort: arrowFlightPort,
 			Protocol:      corev1.ProtocolTCP,
 		})

--- a/pkg/common/utils/resource/service.go
+++ b/pkg/common/utils/resource/service.go
@@ -18,15 +18,16 @@
 package resource
 
 import (
+	"strings"
+
 	dv1 "github.com/apache/doris-operator/api/disaggregated/v1"
-	"github.com/apache/doris-operator/api/doris/v1"
+	v1 "github.com/apache/doris-operator/api/doris/v1"
 	"github.com/apache/doris-operator/pkg/common/utils/hash"
 	"github.com/apache/doris-operator/pkg/common/utils/set"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
-	"strings"
 )
 
 // HashService service hash components
@@ -254,27 +255,39 @@ func getMetaServiceContainerPorts(config map[string]interface{}) []corev1.Contai
 }
 
 func getFeContainerPorts(config map[string]interface{}) []corev1.ContainerPort {
-	return []corev1.ContainerPort{{
-		Name:          GetPortKey(HTTP_PORT),
-		ContainerPort: GetPort(config, HTTP_PORT),
-		Protocol:      corev1.ProtocolTCP,
-	}, {
-		Name:          GetPortKey(RPC_PORT),
-		ContainerPort: GetPort(config, RPC_PORT),
-		Protocol:      corev1.ProtocolTCP,
-	}, {
-		Name:          GetPortKey(QUERY_PORT),
-		ContainerPort: GetPort(config, QUERY_PORT),
-		Protocol:      corev1.ProtocolTCP,
-	}, {
-		Name:          GetPortKey(EDIT_LOG_PORT),
-		ContainerPort: GetPort(config, EDIT_LOG_PORT),
-		Protocol:      corev1.ProtocolTCP,
-	}}
-}
+	ports := []corev1.ContainerPort{
+		{
+			Name:          GetPortKey(HTTP_PORT),
+			ContainerPort: GetPort(config, HTTP_PORT),
+			Protocol:      corev1.ProtocolTCP,
+		}, {
+			Name:          GetPortKey(RPC_PORT),
+			ContainerPort: GetPort(config, RPC_PORT),
+			Protocol:      corev1.ProtocolTCP,
+		}, {
+			Name:          GetPortKey(QUERY_PORT),
+			ContainerPort: GetPort(config, QUERY_PORT),
+			Protocol:      corev1.ProtocolTCP,
+		}, {
+			Name:          GetPortKey(EDIT_LOG_PORT),
+			ContainerPort: GetPort(config, EDIT_LOG_PORT),
+			Protocol:      corev1.ProtocolTCP,
+		},
+	}
 
+	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
+	if arrowFlightPort != -1 {
+		ports = append(ports, corev1.ContainerPort{
+			Name:          GetPortKey(ARROW_FLIGHT_SQL_PORT),
+			ContainerPort: arrowFlightPort,
+			Protocol:      corev1.ProtocolTCP,
+		})
+	}
+
+	return ports
+}
 func getBeContainerPorts(config map[string]interface{}) []corev1.ContainerPort {
-	return []corev1.ContainerPort{
+	ports := []corev1.ContainerPort{
 		{
 			Name:          GetPortKey(BE_PORT),
 			ContainerPort: GetPort(config, BE_PORT),
@@ -292,6 +305,17 @@ func getBeContainerPorts(config map[string]interface{}) []corev1.ContainerPort {
 			Protocol:      corev1.ProtocolTCP,
 		},
 	}
+
+	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
+	if arrowFlightPort != -1 {
+		ports = append(ports, corev1.ContainerPort{
+			Name:          GetPortKey(ARROW_FLIGHT_SQL_PORT),
+			ContainerPort: arrowFlightPort,
+			Protocol:      corev1.ProtocolTCP,
+		})
+	}
+
+	return ports
 }
 
 func getBrokerContainerPorts(config map[string]interface{}) []corev1.ContainerPort {

--- a/pkg/common/utils/resource/service.go
+++ b/pkg/common/utils/resource/service.go
@@ -278,8 +278,7 @@ func getFeContainerPorts(config map[string]interface{}) []corev1.ContainerPort {
 	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
 	if arrowFlightPort != -1 {
 		ports = append(ports, corev1.ContainerPort{
-			// GetPortKey(ARROW_FLIGHT_SQL_PORT) Hardcoding for now. In Kubernetes, container port names must be no more than 15 characters.
-			Name:          "arrow-flight",
+			Name:          GetPortKey(ARROW_FLIGHT_SQL_PORT),
 			ContainerPort: arrowFlightPort,
 			Protocol:      corev1.ProtocolTCP,
 		})
@@ -310,8 +309,7 @@ func getBeContainerPorts(config map[string]interface{}) []corev1.ContainerPort {
 	arrowFlightPort := GetPort(config, ARROW_FLIGHT_SQL_PORT)
 	if arrowFlightPort != -1 {
 		ports = append(ports, corev1.ContainerPort{
-			// GetPortKey(ARROW_FLIGHT_SQL_PORT) Hardcoding for now. In Kubernetes, container port names must be no more than 15 characters.
-			Name:          "arrow-flight",
+			Name:          GetPortKey(ARROW_FLIGHT_SQL_PORT),
 			ContainerPort: arrowFlightPort,
 			Protocol:      corev1.ProtocolTCP,
 		})
@@ -352,7 +350,7 @@ func GetPortKey(configKey string) string {
 	case BRPC_LISTEN_PORT:
 		return "brpc-port"
 	case ARROW_FLIGHT_SQL_PORT:
-		return "arrow-flight-port"
+		return "arrow-flight"
 	default:
 		return ""
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #294

Problem Summary:
Expose Arrow Flight SQL ports as container ports in BEs and FEs pods #294

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - Tested locally in Minikube

- Behavior changed:
    - No. Just aesthetics exposing the ports on the pod.

- Does this need documentation?
No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

