### PR TITLE
[fix](dcr) fix cluster updated and add safe shield for scale down fe

### DIFF
--- a/pkg/common/utils/k8s/client.go
+++ b/pkg/common/utils/k8s/client.go
@@ -110,6 +110,15 @@ func ApplyStatefulSet(ctx context.Context, k8sclient client.Client, st *appv1.St
 	return err
 }
 
+func ApplyDorisCluster(ctx context.Context, k8sclient client.Client, dcr *dorisv1.DorisCluster) error {
+	err := PatchClientObject(ctx, k8sclient, dcr)
+	if err == nil || apierrors.IsConflict(err) {
+		return nil
+	}
+
+	return err
+}
+
 func GetStatefulSet(ctx context.Context, k8sclient client.Client, namespace, name string) (*appv1.StatefulSet, error) {
 	var est appv1.StatefulSet
 	err := k8sclient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &est)

--- a/pkg/common/utils/mysql/doris.go
+++ b/pkg/common/utils/mysql/doris.go
@@ -111,7 +111,7 @@ func BuildSeqNumberToFrontendMap(frontends []*Frontend, ipMap map[string]string,
 }
 
 // FindNeedDeletedFrontends means descending sort fe by index and return top needRemovedAmount
-func FindNeedDeletedFrontends(frontendMap map[int]*Frontend, needRemovedAmount int32) []*Frontend {
+func FindNeedDeletedObservers(frontendMap map[int]*Frontend, needRemovedAmount int32) []*Frontend {
 	var topFrontends []*Frontend
 	if int(needRemovedAmount) <= len(frontendMap) {
 		keys := make([]int, 0, len(frontendMap))

--- a/pkg/controller/doriscluster_controller.go
+++ b/pkg/controller/doriscluster_controller.go
@@ -36,6 +36,7 @@ package controller
 import (
 	"context"
 	dorisv1 "github.com/apache/doris-operator/api/doris/v1"
+	"github.com/apache/doris-operator/pkg/common/utils/k8s"
 	"github.com/apache/doris-operator/pkg/controller/sub_controller"
 	"github.com/apache/doris-operator/pkg/controller/sub_controller/be"
 	bk "github.com/apache/doris-operator/pkg/controller/sub_controller/broker"
@@ -150,7 +151,27 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
+	//if dcr has updated by doris operator, should update it in apiserver. if not ignore it.
+	if err = r.revertDorisClusterSomeField(ctx, &edcr, dcr); err != nil {
+		klog.Errorf("DorisClusterReconciler updateDorisClusterToOld update dorisCluster namespace=%s, name=%s failed, err=%s", dcr.Namespace, dcr.Name, err.Error())
+		return requeueIfError(err)
+	}
+
 	return r.updateDorisClusterStatus(ctx, dcr)
+}
+
+//if cluster spec be reverted, doris operator should revert to old.
+//this action is not good, but this will be a good shield for scale down of fe.
+func(r *DorisClusterReconciler) revertDorisClusterSomeField(ctx context.Context, getDcr, updatedDcr *dorisv1.DorisCluster) error {
+	if *getDcr.Spec.FeSpec.Replicas != *updatedDcr.Spec.FeSpec.Replicas {
+		return k8s.ApplyDorisCluster(ctx, r.Client, updatedDcr)
+	}
+
+	return nil
+}
+
+func(r *DorisClusterReconciler) updateDorisCluster(ctx context.Context, dcr *dorisv1.DorisCluster) error {
+	return k8s.ApplyDorisCluster(ctx, r.Client, dcr)
 }
 
 func (r *DorisClusterReconciler) clearNoEffectResources(context context.Context, cluster *dorisv1.DorisCluster) {

--- a/pkg/controller/doriscluster_controller.go
+++ b/pkg/controller/doriscluster_controller.go
@@ -152,7 +152,7 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	//if dcr has updated by doris operator, should update it in apiserver. if not ignore it.
-	if err = r.revertDorisClusterSomeField(ctx, &edcr, dcr); err != nil {
+	if err = r.revertDorisClusterSomeFields(ctx, &edcr, dcr); err != nil {
 		klog.Errorf("DorisClusterReconciler updateDorisClusterToOld update dorisCluster namespace=%s, name=%s failed, err=%s", dcr.Namespace, dcr.Name, err.Error())
 		return requeueIfError(err)
 	}
@@ -162,7 +162,7 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 //if cluster spec be reverted, doris operator should revert to old.
 //this action is not good, but this will be a good shield for scale down of fe.
-func(r *DorisClusterReconciler) revertDorisClusterSomeField(ctx context.Context, getDcr, updatedDcr *dorisv1.DorisCluster) error {
+func(r *DorisClusterReconciler) revertDorisClusterSomeFields(ctx context.Context, getDcr, updatedDcr *dorisv1.DorisCluster) error {
 	if *getDcr.Spec.FeSpec.Replicas != *updatedDcr.Spec.FeSpec.Replicas {
 		return k8s.ApplyDorisCluster(ctx, r.Client, updatedDcr)
 	}

--- a/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/controller.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/controller.go
@@ -371,7 +371,7 @@ func (dfc *DisaggregatedFEController) dropFEBySQLClient(ctx context.Context, k8s
 			return nil
 		}
 	}
-	observes := mysql.FindNeedDeletedFrontends(frontendMap, needRemovedAmount)
+	observes := mysql.FindNeedDeletedObservers(frontendMap, needRemovedAmount)
 	// drop node and return
 	return masterDBClient.DropObserver(observes)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
       restrict only scale down observers.
       1. fe replicas = 1 => scale up replicas=2. scale up. expectation replicas=2
       2. fe replicas =2 => scale down replicas=1 scale down  failed. expectation replicas=2 (election number in default =3)
       3. fe replicas=5 => scale down replicas=4 scale down success. expectation replicas=4(election number in default=3)
       4. fe replicas=4=>scale down replicas=2 scale down one pod. expectation replicas=3(election number in default=3)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->
     when scale -down followers will not be allowed.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

