### PR TITLE
[Improvement] prepareStatefulsetApply

### DIFF
--- a/pkg/controller/sub_controller/be/prepare_modify.go
+++ b/pkg/controller/sub_controller/be/prepare_modify.go
@@ -18,11 +18,13 @@
 package be
 
 import (
+	"context"
+
 	v1 "github.com/apache/doris-operator/api/doris/v1"
 )
 
 // prepareStatefulsetApply means Pre-operation and status control on the client side
-func (be *Controller) prepareStatefulsetApply(dcr *v1.DorisCluster, oldStatus v1.ComponentStatus) error {
+func (be *Controller) prepareStatefulsetApply(ctx context.Context, dcr *v1.DorisCluster, oldStatus v1.ComponentStatus) error {
 
 	// be rolling restart
 	// check 1: be Phase is Available


### PR DESCRIPTION
### What problem does this PR solve?
fix make build error
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
prepareStatefulsetApply is missing parameters 'ctx'.
`pkg/controller/sub_controller/be/controller.go:93:48: too many arguments in call to be.prepareStatefulsetApply`
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [x] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

