### PR TITLE
 Add support for pod annotations in doris Helm charts

### DIFF
--- a/helm-charts/doris/templates/doriscluster.yaml
+++ b/helm-charts/doris/templates/doriscluster.yaml
@@ -38,6 +38,10 @@ spec:
   authSecret: {{ template "doriscluster.secret.name" . }}
   {{- end }}
   feSpec:
+    {{- if .Values.feSpec.annotations }}
+    annotations:
+    {{- toYaml .Values.feSpec.annotations | nindent 6 }}
+    {{- end }}
     replicas: {{ .Values.feSpec.replicas }}
     {{- if .Values.feSpec.electionNumber }}
     electionNumber: {{ .Values.feSpec.electionNumber }}
@@ -123,6 +127,10 @@ spec:
     {{- end }}
     {{- end }}
   beSpec:
+    {{- if .Values.beSpec.annotations }}
+    annotations:
+    {{- toYaml .Values.beSpec.annotations | nindent 6 }}
+    {{- end }}
     replicas: {{ .Values.beSpec.replicas }}
     {{- if .Values.beSpec.labels }}
     podLabels:
@@ -206,6 +214,10 @@ spec:
     {{- end }}
   {{- if .Values.dorisCluster.enabledCn }}
   cnSpec:
+    {{- if .Values.cnSpec.annotations }}
+    annotations:
+    {{- toYaml .Values.cnSpec.annotations | nindent 6 }}
+    {{- end }}
     replicas: {{ .Values.cnSpec.replicas }}
 
     {{- if .Values.cnSpec.labels }}
@@ -300,6 +312,10 @@ spec:
 
   {{- if .Values.dorisCluster.enabledBroker }}
   brokerSpec:
+    {{- if .Values.brokerSpec.annotations }}
+    annotations:
+    {{- toYaml .Values.brokerSpec.annotations | nindent 6 }}
+    {{- end }}
     replicas: {{ .Values.brokerSpec.replicas }}
 
     {{- if .Values.brokerSpec.labels }}

--- a/helm-charts/doris/values.yaml
+++ b/helm-charts/doris/values.yaml
@@ -44,6 +44,8 @@ dorisCluster:
   # password: dDBwLVNlY3JldA==
 
 feSpec:
+  # annotations for fe pods and service
+  # annotations: {}
   replicas: 3
   # electionNumber represents `FOLLOWER` number, replicas - electionNumber as `OBSERVER`
   # electionNumber: 3
@@ -210,6 +212,8 @@ feSpec:
     # command: [ "/sbin/sysctl", "-w", "vm.max_map_count=2000000" ]
 
 beSpec:
+  # annotations for be pods and service
+  # annotations: {}
   replicas: 3
   # the pod labels for user select or classify pods.
   labels: {}
@@ -375,6 +379,8 @@ beSpec:
     # command: [ "/sbin/sysctl", "-w", "vm.max_map_count=2000000" ]
 
 cnSpec:
+  # annotations for cn pods and service
+  # annotations: {}
   replicas: 3
   # the pod labels for user select or classify pods.
   labels: {}
@@ -556,6 +562,8 @@ cnSpec:
       #       averageUtilization: 30
 
 brokerSpec:
+  # annotations for broker pods and service
+  # annotations: {}
   replicas: 3
   # the pod labels for user select or classify pods.
   labels: {}

--- a/helm-charts/doris/values.yaml
+++ b/helm-charts/doris/values.yaml
@@ -45,7 +45,7 @@ dorisCluster:
 
 feSpec:
   # annotations for fe pods and service
-  # annotations: {}
+  annotations: {}
   replicas: 3
   # electionNumber represents `FOLLOWER` number, replicas - electionNumber as `OBSERVER`
   # electionNumber: 3
@@ -213,7 +213,7 @@ feSpec:
 
 beSpec:
   # annotations for be pods and service
-  # annotations: {}
+  annotations: {}
   replicas: 3
   # the pod labels for user select or classify pods.
   labels: {}
@@ -380,7 +380,7 @@ beSpec:
 
 cnSpec:
   # annotations for cn pods and service
-  # annotations: {}
+  annotations: {}
   replicas: 3
   # the pod labels for user select or classify pods.
   labels: {}
@@ -563,7 +563,7 @@ cnSpec:
 
 brokerSpec:
   # annotations for broker pods and service
-  # annotations: {}
+  annotations: {}
   replicas: 3
   # the pod labels for user select or classify pods.
   labels: {}


### PR DESCRIPTION
# Add support for pod annotations in Helm charts

## What this PR does

This PR adds support for setting pod annotations through Helm values. While the CRD already supports pod annotations configuration, this functionality was missing in the Helm charts.

## Changes

- Added `podAnnotations` field in `values.yaml` to allow users to specify custom pod annotations
- Updated the pod template in deployment to include the annotations
- Added documentation and example usage in `values.yaml`

## Example Usage

Users can now set pod annotations in their `values.yaml`:
