### PR TITLE
[feature](dcr)watch configmap modify and restart nodes

### DIFF
--- a/api/doris/v1/doriscluster_util.go
+++ b/api/doris/v1/doriscluster_util.go
@@ -378,3 +378,33 @@ func (dcr *DorisCluster) GetElectionNumber() int32 {
 	}
 	return DefaultFeElectionNumber
 }
+
+func GetRestartAnnotationKey(componentType ComponentType) string {
+	var restartAnnotationsKey string
+	switch componentType {
+	case Component_FE:
+		restartAnnotationsKey = FERestartAt
+	case Component_BE:
+		restartAnnotationsKey = BERestartAt
+	default:
+		klog.Infof("GetRestartAnnotationKey the componentType %s is not supported.", componentType)
+	}
+	return restartAnnotationsKey
+
+}
+
+func (dcr *DorisCluster) GetComponentStatus(componentType ComponentType) *ComponentStatus {
+	switch componentType {
+	case Component_FE:
+		return dcr.Status.FEStatus
+	case Component_BE:
+		return dcr.Status.BEStatus
+	case Component_CN:
+		return &dcr.Status.CnStatus.ComponentStatus
+	case Component_Broker:
+		return dcr.Status.BrokerStatus
+	default:
+		klog.Infof("GetComponentStatus the componentType %s is not supported.", componentType)
+	}
+	return nil
+}

--- a/api/doris/v1/types.go
+++ b/api/doris/v1/types.go
@@ -49,9 +49,9 @@ type DorisClusterSpec struct {
 	// the password key is `password`. the username defaults to `root` and is omitempty.
 	AuthSecret string `json:"authSecret,omitempty"`
 
-	// Enable configmap monitoring, default is false.
-	// When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
-	EnableWatchConfigmap bool `json:"enableWatchConfigmap,omitempty"`
+	// EnableRestartWhenConfigChange configmap monitoring, default is false.
+	// When EnableRestartWhenConfigChange is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+	EnableRestartWhenConfigChange bool `json:"enableRestartWhenConfigChange,omitempty"`
 }
 
 // AdminUser describe administrator for manage components in specified cluster.
@@ -391,7 +391,7 @@ type ComponentStatus struct {
 	//the name of fe service exposed for user.
 	AccessService string `json:"accessService,omitempty"`
 
-	CoreConfigMapID string `json:"coreConfigMapID,omitempty"`
+	CoreConfigMapHashValue string `json:"coreConfigMapHashValue,omitempty"`
 
 	//FailedInstances failed pod names.
 	FailedMembers []string `json:"failedInstances,omitempty"`

--- a/api/doris/v1/types.go
+++ b/api/doris/v1/types.go
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 package v1
 
 import (
@@ -49,6 +48,10 @@ type DorisClusterSpec struct {
 	// the name of secret that type is `kubernetes.io/basic-auth` and contains keys username, password for management doris node in cluster as fe, be register.
 	// the password key is `password`. the username defaults to `root` and is omitempty.
 	AuthSecret string `json:"authSecret,omitempty"`
+
+	// Enable configmap monitoring, default is false.
+	// When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+	EnableWatchConfigmap bool `json:"enableWatchConfigmap,omitempty"`
 }
 
 // AdminUser describe administrator for manage components in specified cluster.
@@ -86,8 +89,8 @@ type BeSpec struct {
 	// Default System Init means that the container must be started in privileged mode.
 	// Default System Init configuration is implemented through the initContainers of the pod, so changes to this configuration may be ignored by k8s when it is not the first deployment.
 	SkipDefaultSystemInit bool `json:"skipDefaultSystemInit,omitempty"`
-	
-    //EnableFeAffinity schedule the be pod on the hosts that have fe pod. when in test situation or have 3 fe and 3 be nodes, and wants one fe and one be in same host.
+
+	//EnableFeAffinity schedule the be pod on the hosts that have fe pod. when in test situation or have 3 fe and 3 be nodes, and wants one fe and one be in same host.
 	//the weight of antiAffinity in same node is greater than this affinity.
 	EnableFeAffinity bool `json:"enableFeAffinity,omitempty"`
 }
@@ -387,6 +390,8 @@ type ComponentStatus struct {
 	// DorisComponentStatus represents the status of a doris component.
 	//the name of fe service exposed for user.
 	AccessService string `json:"accessService,omitempty"`
+
+	CoreConfigMapID string `json:"coreConfigMapID,omitempty"`
 
 	//FailedInstances failed pod names.
 	FailedMembers []string `json:"failedInstances,omitempty"`

--- a/config/crd/bases/crds.yaml
+++ b/config/crd/bases/crds.yaml
@@ -6108,10 +6108,10 @@ spec:
                 required:
                 - image
                 type: object
-              enableWatchConfigmap:
+              enableRestartWhenConfigChange:
                 description: |-
-                  Enable configmap monitoring, default is false.
-                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                  EnableRestartWhenConfigChange configmap monitoring, default is false.
+                  When EnableRestartWhenConfigChange is true, changing the doris core configmap will cause a rolling restart of the corresponding node
                 type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
@@ -7951,7 +7951,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8004,7 +8004,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8057,7 +8057,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8120,7 +8120,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.

--- a/config/crd/bases/crds.yaml
+++ b/config/crd/bases/crds.yaml
@@ -6108,6 +6108,11 @@ spec:
                 required:
                 - image
                 type: object
+              enableWatchConfigmap:
+                description: |-
+                  Enable configmap monitoring, default is false.
+                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
                   operator.
@@ -7946,6 +7951,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -7997,6 +8004,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8048,6 +8057,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8109,6 +8120,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:

--- a/config/crd/bases/doris.apache.com_dorisclusters.yaml
+++ b/config/crd/bases/doris.apache.com_dorisclusters.yaml
@@ -6108,10 +6108,10 @@ spec:
                 required:
                 - image
                 type: object
-              enableWatchConfigmap:
+              enableRestartWhenConfigChange:
                 description: |-
-                  Enable configmap monitoring, default is false.
-                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                  EnableRestartWhenConfigChange configmap monitoring, default is false.
+                  When EnableRestartWhenConfigChange is true, changing the doris core configmap will cause a rolling restart of the corresponding node
                 type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
@@ -7951,7 +7951,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8004,7 +8004,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8057,7 +8057,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8120,7 +8120,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.

--- a/config/crd/bases/doris.apache.com_dorisclusters.yaml
+++ b/config/crd/bases/doris.apache.com_dorisclusters.yaml
@@ -6108,6 +6108,11 @@ spec:
                 required:
                 - image
                 type: object
+              enableWatchConfigmap:
+                description: |-
+                  Enable configmap monitoring, default is false.
+                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
                   operator.
@@ -7946,6 +7951,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -7997,6 +8004,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8048,6 +8057,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8109,6 +8120,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:

--- a/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
+++ b/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
@@ -6108,10 +6108,10 @@ spec:
                 required:
                 - image
                 type: object
-              enableWatchConfigmap:
+              enableRestartWhenConfigChange:
                 description: |-
-                  Enable configmap monitoring, default is false.
-                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                  EnableRestartWhenConfigChange configmap monitoring, default is false.
+                  When EnableRestartWhenConfigChange is true, changing the doris core configmap will cause a rolling restart of the corresponding node
                 type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
@@ -7951,7 +7951,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8004,7 +8004,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8057,7 +8057,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8120,7 +8120,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.

--- a/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
+++ b/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
@@ -6108,6 +6108,11 @@ spec:
                 required:
                 - image
                 type: object
+              enableWatchConfigmap:
+                description: |-
+                  Enable configmap monitoring, default is false.
+                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
                   operator.
@@ -7946,6 +7951,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -7997,6 +8004,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8048,6 +8057,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8109,6 +8120,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:

--- a/helm-charts/doris-operator/crds/doris.apache.com_dorisclusters.yaml
+++ b/helm-charts/doris-operator/crds/doris.apache.com_dorisclusters.yaml
@@ -6108,10 +6108,10 @@ spec:
                 required:
                 - image
                 type: object
-              enableWatchConfigmap:
+              enableRestartWhenConfigChange:
                 description: |-
-                  Enable configmap monitoring, default is false.
-                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                  EnableRestartWhenConfigChange configmap monitoring, default is false.
+                  When EnableRestartWhenConfigChange is true, changing the doris core configmap will cause a rolling restart of the corresponding node
                 type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
@@ -7951,7 +7951,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8004,7 +8004,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8057,7 +8057,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
@@ -8120,7 +8120,7 @@ spec:
                     - phase
                     - reason
                     type: object
-                  coreConfigMapID:
+                  coreConfigMapHashValue:
                     type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.

--- a/helm-charts/doris-operator/crds/doris.apache.com_dorisclusters.yaml
+++ b/helm-charts/doris-operator/crds/doris.apache.com_dorisclusters.yaml
@@ -6108,6 +6108,11 @@ spec:
                 required:
                 - image
                 type: object
+              enableWatchConfigmap:
+                description: |-
+                  Enable configmap monitoring, default is false.
+                  When EnableWatchConfigmap is true, changing the doris core configmap will cause a rolling restart of the corresponding node
+                type: boolean
               feSpec:
                 description: defines the fe cluster state that will be created by
                   operator.
@@ -7946,6 +7951,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -7997,6 +8004,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8048,6 +8057,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:
@@ -8109,6 +8120,8 @@ spec:
                     - phase
                     - reason
                     type: object
+                  coreConfigMapID:
+                    type: string
                   creatingInstances:
                     description: CreatingInstances in creating pod names.
                     items:

--- a/pkg/common/utils/resource/configmap.go
+++ b/pkg/common/utils/resource/configmap.go
@@ -148,3 +148,57 @@ func GetMountConfigMapInfo(c dorisv1.ConfigMapInfo) (finalConfigMaps []dorisv1.M
 
 	return finalConfigMaps
 }
+
+func getDorisConfigInfo(dcr *dorisv1.DorisCluster, componentType dorisv1.ComponentType) string {
+
+	var cmInfo dorisv1.ConfigMapInfo
+	switch componentType {
+	case dorisv1.Component_FE:
+		cmInfo = dcr.Spec.FeSpec.ConfigMapInfo
+	case dorisv1.Component_BE:
+		cmInfo = dcr.Spec.BeSpec.ConfigMapInfo
+	case dorisv1.Component_CN:
+		cmInfo = dcr.Spec.CnSpec.ConfigMapInfo
+	case dorisv1.Component_Broker:
+		cmInfo = dcr.Spec.BrokerSpec.ConfigMapInfo
+	default:
+		klog.Infof("getDorisConfigInfo: the componentType: %s have not default ResolveKey", componentType)
+	}
+
+	maps := GetMountConfigMapInfo(cmInfo)
+	for i := range maps {
+		if maps[i].MountPath == "" || maps[i].MountPath == ConfigEnvPath {
+			return maps[i].ConfigMapName
+		}
+	}
+	return ""
+}
+
+func GetDorisCoreConfigMaps(dcr *dorisv1.DorisCluster) map[dorisv1.ComponentType]string {
+	dorisCoreConfigMaps := map[dorisv1.ComponentType]string{}
+	if dcr.Spec.FeSpec != nil {
+		if cm := getDorisConfigInfo(dcr, dorisv1.Component_FE); cm != "" {
+			dorisCoreConfigMaps[dorisv1.Component_FE] = cm
+		}
+	}
+
+	if dcr.Spec.BeSpec != nil {
+		if cm := getDorisConfigInfo(dcr, dorisv1.Component_BE); cm != "" {
+			dorisCoreConfigMaps[dorisv1.Component_BE] = cm
+		}
+	}
+
+	if dcr.Spec.CnSpec != nil {
+		if cm := getDorisConfigInfo(dcr, dorisv1.Component_CN); cm != "" {
+			dorisCoreConfigMaps[dorisv1.Component_CN] = cm
+		}
+	}
+
+	if dcr.Spec.BrokerSpec != nil {
+		if cm := getDorisConfigInfo(dcr, dorisv1.Component_Broker); cm != "" {
+			dorisCoreConfigMaps[dorisv1.Component_Broker] = cm
+		}
+	}
+
+	return dorisCoreConfigMaps
+}

--- a/pkg/common/utils/resource/configmap.go
+++ b/pkg/common/utils/resource/configmap.go
@@ -149,8 +149,8 @@ func GetMountConfigMapInfo(c dorisv1.ConfigMapInfo) (finalConfigMaps []dorisv1.M
 	return finalConfigMaps
 }
 
-func getCoreCmName(dcr *dorisv1.DorisCluster, componentType dorisv1.ComponentType) string {
-
+// getDorisCoreConfigMapName return a configmap`s name include doris configurations such as fe.conf/be.conf
+func getDorisCoreConfigMapName(dcr *dorisv1.DorisCluster, componentType dorisv1.ComponentType) string {
 	var cmInfo dorisv1.ConfigMapInfo
 	switch componentType {
 	case dorisv1.Component_FE:
@@ -177,25 +177,25 @@ func getCoreCmName(dcr *dorisv1.DorisCluster, componentType dorisv1.ComponentTyp
 func GetDorisCoreConfigMapNames(dcr *dorisv1.DorisCluster) map[dorisv1.ComponentType]string {
 	dorisCoreConfigMaps := map[dorisv1.ComponentType]string{}
 	if dcr.Spec.FeSpec != nil {
-		if cm := getCoreCmName(dcr, dorisv1.Component_FE); cm != "" {
+		if cm := getDorisCoreConfigMapName(dcr, dorisv1.Component_FE); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_FE] = cm
 		}
 	}
 
 	if dcr.Spec.BeSpec != nil {
-		if cm := getCoreCmName(dcr, dorisv1.Component_BE); cm != "" {
+		if cm := getDorisCoreConfigMapName(dcr, dorisv1.Component_BE); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_BE] = cm
 		}
 	}
 
 	if dcr.Spec.CnSpec != nil {
-		if cm := getCoreCmName(dcr, dorisv1.Component_CN); cm != "" {
+		if cm := getDorisCoreConfigMapName(dcr, dorisv1.Component_CN); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_CN] = cm
 		}
 	}
 
 	if dcr.Spec.BrokerSpec != nil {
-		if cm := getCoreCmName(dcr, dorisv1.Component_Broker); cm != "" {
+		if cm := getDorisCoreConfigMapName(dcr, dorisv1.Component_Broker); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_Broker] = cm
 		}
 	}

--- a/pkg/common/utils/resource/configmap.go
+++ b/pkg/common/utils/resource/configmap.go
@@ -149,7 +149,7 @@ func GetMountConfigMapInfo(c dorisv1.ConfigMapInfo) (finalConfigMaps []dorisv1.M
 	return finalConfigMaps
 }
 
-func getDorisConfigInfo(dcr *dorisv1.DorisCluster, componentType dorisv1.ComponentType) string {
+func getCoreCmName(dcr *dorisv1.DorisCluster, componentType dorisv1.ComponentType) string {
 
 	var cmInfo dorisv1.ConfigMapInfo
 	switch componentType {
@@ -162,7 +162,7 @@ func getDorisConfigInfo(dcr *dorisv1.DorisCluster, componentType dorisv1.Compone
 	case dorisv1.Component_Broker:
 		cmInfo = dcr.Spec.BrokerSpec.ConfigMapInfo
 	default:
-		klog.Infof("getDorisConfigInfo: the componentType: %s have not default ResolveKey", componentType)
+		klog.Infof("getCoreCmName: the componentType: %s have not default ResolveKey", componentType)
 	}
 
 	maps := GetMountConfigMapInfo(cmInfo)
@@ -177,25 +177,25 @@ func getDorisConfigInfo(dcr *dorisv1.DorisCluster, componentType dorisv1.Compone
 func GetDorisCoreConfigMapNames(dcr *dorisv1.DorisCluster) map[dorisv1.ComponentType]string {
 	dorisCoreConfigMaps := map[dorisv1.ComponentType]string{}
 	if dcr.Spec.FeSpec != nil {
-		if cm := getDorisConfigInfo(dcr, dorisv1.Component_FE); cm != "" {
+		if cm := getCoreCmName(dcr, dorisv1.Component_FE); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_FE] = cm
 		}
 	}
 
 	if dcr.Spec.BeSpec != nil {
-		if cm := getDorisConfigInfo(dcr, dorisv1.Component_BE); cm != "" {
+		if cm := getCoreCmName(dcr, dorisv1.Component_BE); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_BE] = cm
 		}
 	}
 
 	if dcr.Spec.CnSpec != nil {
-		if cm := getDorisConfigInfo(dcr, dorisv1.Component_CN); cm != "" {
+		if cm := getCoreCmName(dcr, dorisv1.Component_CN); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_CN] = cm
 		}
 	}
 
 	if dcr.Spec.BrokerSpec != nil {
-		if cm := getDorisConfigInfo(dcr, dorisv1.Component_Broker); cm != "" {
+		if cm := getCoreCmName(dcr, dorisv1.Component_Broker); cm != "" {
 			dorisCoreConfigMaps[dorisv1.Component_Broker] = cm
 		}
 	}

--- a/pkg/common/utils/resource/configmap.go
+++ b/pkg/common/utils/resource/configmap.go
@@ -174,7 +174,7 @@ func getDorisConfigInfo(dcr *dorisv1.DorisCluster, componentType dorisv1.Compone
 	return ""
 }
 
-func GetDorisCoreConfigMaps(dcr *dorisv1.DorisCluster) map[dorisv1.ComponentType]string {
+func GetDorisCoreConfigMapNames(dcr *dorisv1.DorisCluster) map[dorisv1.ComponentType]string {
 	dorisCoreConfigMaps := map[dorisv1.ComponentType]string{}
 	if dcr.Spec.FeSpec != nil {
 		if cm := getDorisConfigInfo(dcr, dorisv1.Component_FE); cm != "" {

--- a/pkg/common/utils/resource/configmap_test.go
+++ b/pkg/common/utils/resource/configmap_test.go
@@ -181,8 +181,8 @@ func Test_getCoreCmName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getCoreCmName(tt.args.dcr, tt.args.componentType); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getCoreCmName() = %v, want %v", got, tt.want)
+			if got := getDorisCoreConfigMapName(tt.args.dcr, tt.args.componentType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getDorisCoreConfigMapName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/common/utils/resource/configmap_test.go
+++ b/pkg/common/utils/resource/configmap_test.go
@@ -20,6 +20,7 @@ package resource
 import (
 	dorisv1 "github.com/apache/doris-operator/api/doris/v1"
 	corev1 "k8s.io/api/core/v1"
+	"reflect"
 	"strconv"
 	"testing"
 )
@@ -122,5 +123,67 @@ func Test_GetMountConfigMapInfo(t *testing.T) {
 	fc := GetMountConfigMapInfo(c)
 	if len(fc) != 1 {
 		t.Errorf("get mountConfigMapInfo failed, len not equal 1")
+	}
+}
+
+func Test_getDorisConfigInfo(t *testing.T) {
+	type args struct {
+		dcr           *dorisv1.DorisCluster
+		componentType dorisv1.ComponentType
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test1",
+			args: args{
+				dcr: &dorisv1.DorisCluster{
+					Spec: dorisv1.DorisClusterSpec{
+						FeSpec: &dorisv1.FeSpec{
+							BaseSpec: dorisv1.BaseSpec{
+								ConfigMapInfo: dorisv1.ConfigMapInfo{
+									ConfigMapName: "fe-config",
+								},
+							},
+						},
+					},
+				},
+				componentType: dorisv1.Component_FE,
+			},
+			want: "fe-config",
+		},
+		{
+			name: "test2",
+			args: args{dcr: &dorisv1.DorisCluster{
+				Spec: dorisv1.DorisClusterSpec{
+					FeSpec: &dorisv1.FeSpec{
+						BaseSpec: dorisv1.BaseSpec{
+							ConfigMapInfo: dorisv1.ConfigMapInfo{
+								ConfigMapName: "fe-config",
+								ConfigMaps: []dorisv1.MountConfigMapInfo{
+									{
+										ConfigMapName: "fe-config-1",
+										MountPath:     "config",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+				componentType: dorisv1.Component_FE,
+			},
+			want: "fe-config",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getDorisConfigInfo(tt.args.dcr, tt.args.componentType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getDorisConfigInfo() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/common/utils/resource/configmap_test.go
+++ b/pkg/common/utils/resource/configmap_test.go
@@ -126,7 +126,7 @@ func Test_GetMountConfigMapInfo(t *testing.T) {
 	}
 }
 
-func Test_getDorisConfigInfo(t *testing.T) {
+func Test_getCoreCmName(t *testing.T) {
 	type args struct {
 		dcr           *dorisv1.DorisCluster
 		componentType dorisv1.ComponentType
@@ -181,8 +181,8 @@ func Test_getDorisConfigInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getDorisConfigInfo(tt.args.dcr, tt.args.componentType); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getDorisConfigInfo() = %v, want %v", got, tt.want)
+			if got := getCoreCmName(tt.args.dcr, tt.args.componentType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getCoreCmName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/common/utils/set/map.go
+++ b/pkg/common/utils/set/map.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package set
 
 import (

--- a/pkg/common/utils/set/map.go
+++ b/pkg/common/utils/set/map.go
@@ -24,21 +24,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func CompareMaps(map1, map2 map[string]string) bool {
-	if len(map1) != len(map2) {
-		return false
-	}
-
-	for key, value1 := range map1 {
-		value2, exists := map2[key]
-		if !exists || value1 != value2 {
-			return false
-		}
-	}
-
-	return true
-}
-
 func Map2Hash(m map[string]interface{}) string {
 	jsonBytes, err := json.Marshal(m)
 	if err != nil {

--- a/pkg/common/utils/set/map.go
+++ b/pkg/common/utils/set/map.go
@@ -1,0 +1,34 @@
+package set
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"k8s.io/klog/v2"
+)
+
+func CompareMaps(map1, map2 map[string]string) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+
+	for key, value1 := range map1 {
+		value2, exists := map2[key]
+		if !exists || value1 != value2 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func Map2Hash(m map[string]interface{}) string {
+	jsonBytes, err := json.Marshal(m)
+	if err != nil {
+		klog.Errorf("Map2Hash json Marshal failed, err: %s", err.Error())
+		return ""
+	}
+
+	hash := sha256.Sum256(jsonBytes)
+	return hex.EncodeToString(hash[:])
+}

--- a/pkg/common/utils/set/map_test.go
+++ b/pkg/common/utils/set/map_test.go
@@ -1,0 +1,103 @@
+package set
+
+import (
+	"testing"
+)
+
+func Test_CompareMaps(t *testing.T) {
+	tests := []struct {
+		name     string
+		map1     map[string]string
+		map2     map[string]string
+		expected bool
+	}{
+		{
+			name:     "equal maps",
+			map1:     map[string]string{"key1": "value1", "key2": "value2"},
+			map2:     map[string]string{"key1": "value1", "key2": "value2"},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			map1:     map[string]string{"key1": "value1"},
+			map2:     map[string]string{"key1": "value1", "key2": "value2"},
+			expected: false,
+		},
+		{
+			name:     "different keys",
+			map1:     map[string]string{"key1": "value1"},
+			map2:     map[string]string{"key2": "value1"},
+			expected: false,
+		},
+		{
+			name:     "different values",
+			map1:     map[string]string{"key1": "value1"},
+			map2:     map[string]string{"key1": "value2"},
+			expected: false,
+		},
+		{
+			name:     "one empty map",
+			map1:     map[string]string{},
+			map2:     map[string]string{"key1": "value1"},
+			expected: false,
+		},
+		{
+			name:     "both empty maps",
+			map1:     map[string]string{},
+			map2:     map[string]string{},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompareMaps(tt.map1, tt.map2)
+			if got != tt.expected {
+				t.Errorf("CompareMaps() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_Map2Hash(t *testing.T) {
+	tests := []struct {
+		name     string
+		mapInput map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "empty map",
+			mapInput: map[string]interface{}{},
+			expected: "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a", // sha256 hash of an empty map
+		},
+		{
+			name:     "map with one key-value",
+			mapInput: map[string]interface{}{"key1": "value1"},
+			expected: "9874854240b45b4bdbf43fca6110bafce8525aedbeca5babaee0cb137d9a7868", // sha256 hash of {"key1":"value1"}
+		},
+		{
+			name:     "map with multiple key-value pairs",
+			mapInput: map[string]interface{}{"key1": "value1", "key2": "value2"},
+			expected: "b734413c644ec49f6a7c07d88b267244582d6422d89eee955511f6b3c0dcb0f2", // sha256 hash of {"key1":"value1", "key2":"value2"}
+		},
+		{
+			name:     "map with different key order",
+			mapInput: map[string]interface{}{"key2": "value2", "key1": "value1"},
+			expected: "b734413c644ec49f6a7c07d88b267244582d6422d89eee955511f6b3c0dcb0f2", // sha256 hash of {"key2":"value2", "key1":"value1"} should match previous test case
+		},
+		{
+			name:     "map with different values",
+			mapInput: map[string]interface{}{"key1": "value1", "key2": "value3"},
+			expected: "d28ff006564cb178d72850c11e58a8131f40d66418ef4acb6a579cb3c6d1d379", // sha256 hash of {"key1":"value1", "key2":"value3"}
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Map2Hash(tt.mapInput)
+			if got != tt.expected {
+				t.Errorf("Map2Hash() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/common/utils/set/map_test.go
+++ b/pkg/common/utils/set/map_test.go
@@ -21,61 +21,6 @@ import (
 	"testing"
 )
 
-func Test_CompareMaps(t *testing.T) {
-	tests := []struct {
-		name     string
-		map1     map[string]string
-		map2     map[string]string
-		expected bool
-	}{
-		{
-			name:     "equal maps",
-			map1:     map[string]string{"key1": "value1", "key2": "value2"},
-			map2:     map[string]string{"key1": "value1", "key2": "value2"},
-			expected: true,
-		},
-		{
-			name:     "different lengths",
-			map1:     map[string]string{"key1": "value1"},
-			map2:     map[string]string{"key1": "value1", "key2": "value2"},
-			expected: false,
-		},
-		{
-			name:     "different keys",
-			map1:     map[string]string{"key1": "value1"},
-			map2:     map[string]string{"key2": "value1"},
-			expected: false,
-		},
-		{
-			name:     "different values",
-			map1:     map[string]string{"key1": "value1"},
-			map2:     map[string]string{"key1": "value2"},
-			expected: false,
-		},
-		{
-			name:     "one empty map",
-			map1:     map[string]string{},
-			map2:     map[string]string{"key1": "value1"},
-			expected: false,
-		},
-		{
-			name:     "both empty maps",
-			map1:     map[string]string{},
-			map2:     map[string]string{},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := CompareMaps(tt.map1, tt.map2)
-			if got != tt.expected {
-				t.Errorf("CompareMaps() = %v, want %v", got, tt.expected)
-			}
-		})
-	}
-}
-
 func Test_Map2Hash(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/common/utils/set/map_test.go
+++ b/pkg/common/utils/set/map_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package set
 
 import (

--- a/pkg/controller/doriscluster_controller.go
+++ b/pkg/controller/doriscluster_controller.go
@@ -138,7 +138,7 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if dcr.Spec.EnableWatchConfigmap {
-		coreConfigMaps := resource.GetDorisCoreConfigMaps(dcr)
+		coreConfigMaps := resource.GetDorisCoreConfigMapNames(dcr)
 		for componentType := range coreConfigMaps {
 			cmnn := types.NamespacedName{Namespace: dcr.Namespace, Name: coreConfigMaps[componentType]}
 			dcrnn := types.NamespacedName{Namespace: dcr.Namespace, Name: dcr.Name}

--- a/pkg/controller/doriscluster_controller.go
+++ b/pkg/controller/doriscluster_controller.go
@@ -38,7 +38,6 @@ import (
 	dorisv1 "github.com/apache/doris-operator/api/doris/v1"
 	"github.com/apache/doris-operator/pkg/common/utils/k8s"
 	"github.com/apache/doris-operator/pkg/common/utils/resource"
-	"github.com/apache/doris-operator/pkg/common/utils/set"
 	"github.com/apache/doris-operator/pkg/controller/sub_controller"
 	"github.com/apache/doris-operator/pkg/controller/sub_controller/be"
 	bk "github.com/apache/doris-operator/pkg/controller/sub_controller/broker"
@@ -137,7 +136,7 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	if dcr.Spec.EnableWatchConfigmap {
+	if dcr.Spec.EnableRestartWhenConfigChange {
 		coreConfigMaps := resource.GetDorisCoreConfigMapNames(dcr)
 		for componentType := range coreConfigMaps {
 			cmnn := types.NamespacedName{Namespace: dcr.Namespace, Name: coreConfigMaps[componentType]}
@@ -342,31 +341,7 @@ func (r *DorisClusterReconciler) watchConfigMapBuilder(builder *ctrl.Builder) *c
 				return false
 			}
 
-			oldConfigMap, ok := u.ObjectOld.(*corev1.ConfigMap)
-			if !ok {
-				klog.Errorf(
-					"watchConfigMapBuilder UpdateFunc Failed to cast ObjectOld to ConfigMap %s: objectKind=%v, objectName=%s, objectNamespace=%s",
-					"ObjectOld",
-					u.ObjectOld.GetObjectKind().GroupVersionKind(),
-					u.ObjectOld.GetName(),
-					u.ObjectOld.GetNamespace(),
-				)
-				return false
-			}
-
-			newConfigMap, ok := u.ObjectNew.(*corev1.ConfigMap)
-			if !ok {
-				klog.Errorf(
-					"watchConfigMapBuilder UpdateFunc Failed to cast ObjectNew to ConfigMap %s: objectKind=%v, objectName=%s, objectNamespace=%s",
-					"ObjectNew",
-					u.ObjectNew.GetObjectKind().GroupVersionKind(),
-					u.ObjectNew.GetName(),
-					u.ObjectNew.GetNamespace(),
-				)
-				return false
-			}
-			isCmEqual := set.CompareMaps(oldConfigMap.Data, newConfigMap.Data)
-			return !isCmEqual
+			return true
 		},
 	}
 

--- a/pkg/controller/sub_controller/be/controller.go
+++ b/pkg/controller/sub_controller/be/controller.go
@@ -64,7 +64,7 @@ func (be *Controller) Sync(ctx context.Context, dcr *v1.DorisCluster) error {
 		return nil
 	}
 
-	if dcr.Spec.EnableWatchConfigmap {
+	if dcr.Spec.EnableRestartWhenConfigChange {
 		be.CompareConfigmapByStatusAndTriggerRestart(dcr, oldStatus, v1.Component_BE)
 	}
 
@@ -126,7 +126,7 @@ func (be *Controller) UpdateComponentStatus(cluster *v1.DorisCluster) error {
 	}
 
 	newCmHash := be.BuildCoreConfigmapStatusHash(context.Background(), cluster, v1.Component_BE)
-	cluster.Status.BEStatus.CoreConfigMapID = newCmHash
+	cluster.Status.BEStatus.CoreConfigMapHashValue = newCmHash
 
 	return be.ClassifyPodsByStatus(cluster.Namespace, cluster.Status.BEStatus, v1.GenerateStatefulSetSelector(cluster, v1.Component_BE), *cluster.Spec.BeSpec.Replicas, v1.Component_BE)
 }

--- a/pkg/controller/sub_controller/be/controller.go
+++ b/pkg/controller/sub_controller/be/controller.go
@@ -63,6 +63,11 @@ func (be *Controller) Sync(ctx context.Context, dcr *v1.DorisCluster) error {
 	if !be.FeAvailable(dcr) {
 		return nil
 	}
+
+	if dcr.Spec.EnableWatchConfigmap {
+		be.CompareConfigmapByStatusAndTriggerRestart(dcr, oldStatus, v1.Component_BE)
+	}
+
 	beSpec := dcr.Spec.BeSpec
 	//get the be configMap for resolve ports.
 	//2. get config for generate statefulset and service.
@@ -119,6 +124,9 @@ func (be *Controller) UpdateComponentStatus(cluster *v1.DorisCluster) error {
 		cluster.Status.BEStatus = nil
 		return nil
 	}
+
+	newCmHash := be.BuildConfigmapStatus(context.Background(), cluster, v1.Component_BE)
+	cluster.Status.BEStatus.CoreConfigMapID = newCmHash
 
 	return be.ClassifyPodsByStatus(cluster.Namespace, cluster.Status.BEStatus, v1.GenerateStatefulSetSelector(cluster, v1.Component_BE), *cluster.Spec.BeSpec.Replicas, v1.Component_BE)
 }

--- a/pkg/controller/sub_controller/be/controller.go
+++ b/pkg/controller/sub_controller/be/controller.go
@@ -125,7 +125,7 @@ func (be *Controller) UpdateComponentStatus(cluster *v1.DorisCluster) error {
 		return nil
 	}
 
-	newCmHash := be.BuildConfigmapStatus(context.Background(), cluster, v1.Component_BE)
+	newCmHash := be.BuildCoreConfigmapStatusHash(context.Background(), cluster, v1.Component_BE)
 	cluster.Status.BEStatus.CoreConfigMapID = newCmHash
 
 	return be.ClassifyPodsByStatus(cluster.Namespace, cluster.Status.BEStatus, v1.GenerateStatefulSetSelector(cluster, v1.Component_BE), *cluster.Spec.BeSpec.Replicas, v1.Component_BE)

--- a/pkg/controller/sub_controller/be/controller.go
+++ b/pkg/controller/sub_controller/be/controller.go
@@ -65,7 +65,7 @@ func (be *Controller) Sync(ctx context.Context, dcr *v1.DorisCluster) error {
 	}
 
 	if dcr.Spec.EnableRestartWhenConfigChange {
-		be.CompareConfigmapByStatusAndTriggerRestart(dcr, oldStatus, v1.Component_BE)
+		be.CompareConfigmapAndTriggerRestart(dcr, oldStatus, v1.Component_BE)
 	}
 
 	beSpec := dcr.Spec.BeSpec

--- a/pkg/controller/sub_controller/events.go
+++ b/pkg/controller/sub_controller/events.go
@@ -73,6 +73,7 @@ var (
 	MSStatefulsetDeleteFailed       EventReason = "MSStatefulsetDeleteFailed"
 	FDBAddressNotConfiged           EventReason = "FDBAddressNotConfiged"
 	RestartTimeInvalid              EventReason = "RestartTimeInvalid"
+	ConfigMapGetFailed              EventReason = "ConfigMapGetFailed"
 )
 
 type Event struct {

--- a/pkg/controller/sub_controller/fe/controller.go
+++ b/pkg/controller/sub_controller/fe/controller.go
@@ -58,7 +58,7 @@ func (fc *Controller) UpdateComponentStatus(cluster *v1.DorisCluster) error {
 	}
 
 	newCmHash := fc.BuildCoreConfigmapStatusHash(context.Background(), cluster, v1.Component_FE)
-	cluster.Status.FEStatus.CoreConfigMapID = newCmHash
+	cluster.Status.FEStatus.CoreConfigMapHashValue = newCmHash
 
 	return fc.ClassifyPodsByStatus(cluster.Namespace, cluster.Status.FEStatus, v1.GenerateStatefulSetSelector(cluster, v1.Component_FE), *cluster.Spec.FeSpec.Replicas, v1.Component_FE)
 }
@@ -89,7 +89,7 @@ func (fc *Controller) Sync(ctx context.Context, cluster *v1.DorisCluster) error 
 	}
 	fc.InitStatus(cluster, v1.Component_FE)
 
-	if cluster.Spec.EnableWatchConfigmap {
+	if cluster.Spec.EnableRestartWhenConfigChange {
 		fc.CompareConfigmapByStatusAndTriggerRestart(cluster, oldStatus, v1.Component_FE)
 	}
 

--- a/pkg/controller/sub_controller/fe/controller.go
+++ b/pkg/controller/sub_controller/fe/controller.go
@@ -90,7 +90,7 @@ func (fc *Controller) Sync(ctx context.Context, cluster *v1.DorisCluster) error 
 	fc.InitStatus(cluster, v1.Component_FE)
 
 	if cluster.Spec.EnableRestartWhenConfigChange {
-		fc.CompareConfigmapByStatusAndTriggerRestart(cluster, oldStatus, v1.Component_FE)
+		fc.CompareConfigmapAndTriggerRestart(cluster, oldStatus, v1.Component_FE)
 	}
 
 	feSpec := cluster.Spec.FeSpec

--- a/pkg/controller/sub_controller/fe/controller.go
+++ b/pkg/controller/sub_controller/fe/controller.go
@@ -57,6 +57,9 @@ func (fc *Controller) UpdateComponentStatus(cluster *v1.DorisCluster) error {
 		return nil
 	}
 
+	newCmHash := fc.BuildConfigmapStatus(context.Background(), cluster, v1.Component_FE)
+	cluster.Status.FEStatus.CoreConfigMapID = newCmHash
+
 	return fc.ClassifyPodsByStatus(cluster.Namespace, cluster.Status.FEStatus, v1.GenerateStatefulSetSelector(cluster, v1.Component_FE), *cluster.Spec.FeSpec.Replicas, v1.Component_FE)
 }
 
@@ -85,6 +88,10 @@ func (fc *Controller) Sync(ctx context.Context, cluster *v1.DorisCluster) error 
 		oldStatus = *(cluster.Status.FEStatus.DeepCopy())
 	}
 	fc.InitStatus(cluster, v1.Component_FE)
+
+	if cluster.Spec.EnableWatchConfigmap {
+		fc.CompareConfigmapByStatusAndTriggerRestart(cluster, oldStatus, v1.Component_FE)
+	}
 
 	feSpec := cluster.Spec.FeSpec
 	//get the fe configMap for resolve ports.

--- a/pkg/controller/sub_controller/fe/controller.go
+++ b/pkg/controller/sub_controller/fe/controller.go
@@ -57,7 +57,7 @@ func (fc *Controller) UpdateComponentStatus(cluster *v1.DorisCluster) error {
 		return nil
 	}
 
-	newCmHash := fc.BuildConfigmapStatus(context.Background(), cluster, v1.Component_FE)
+	newCmHash := fc.BuildCoreConfigmapStatusHash(context.Background(), cluster, v1.Component_FE)
 	cluster.Status.FEStatus.CoreConfigMapID = newCmHash
 
 	return fc.ClassifyPodsByStatus(cluster.Namespace, cluster.Status.FEStatus, v1.GenerateStatefulSetSelector(cluster, v1.Component_FE), *cluster.Spec.FeSpec.Replicas, v1.Component_FE)

--- a/pkg/controller/sub_controller/sub_controller.go
+++ b/pkg/controller/sub_controller/sub_controller.go
@@ -599,13 +599,13 @@ func (d *SubDefaultController) initBEStatus(cluster *dorisv1.DorisCluster) {
 	cluster.Status.BEStatus = status
 }
 
-// BuildCoreConfigmapStatusHash :
+// BuildCoreConfigmapStatusHash
 // resolve configmap for doris core configuration file (fe.conf/be.conf),
 // After parsing the configuration file, it is converted into a configured map,
 // And return the map's hash
 func (d *SubDefaultController) BuildCoreConfigmapStatusHash(ctx context.Context, dcr *dorisv1.DorisCluster, componentType dorisv1.ComponentType) string {
-	maps := resource.GetDorisCoreConfigMapNames(dcr)
-	cmName := maps[componentType]
+	names := resource.GetDorisCoreConfigMapNames(dcr)
+	cmName := names[componentType]
 	if cmName != "" {
 		cm, err := k8s.GetConfigMap(ctx, d.K8sclient, dcr.Namespace, cmName)
 		if err != nil {
@@ -626,10 +626,10 @@ func (d *SubDefaultController) BuildCoreConfigmapStatusHash(ctx context.Context,
 	return ""
 }
 
-// CompareConfigmapByStatusAndTriggerRestart
+// CompareConfigmapAndTriggerRestart
 // 1. Compared by configmap Resolve file to map`s hash
 // 2. Add restart trigger DCR
-func (d *SubDefaultController) CompareConfigmapByStatusAndTriggerRestart(dcr *dorisv1.DorisCluster, oldStatus dorisv1.ComponentStatus, componentType dorisv1.ComponentType) {
+func (d *SubDefaultController) CompareConfigmapAndTriggerRestart(dcr *dorisv1.DorisCluster, oldStatus dorisv1.ComponentStatus, componentType dorisv1.ComponentType) {
 	oldCmHash := oldStatus.CoreConfigMapHashValue
 	if oldCmHash == "" {
 		// oldCmHash is "" means the following situations:
@@ -652,7 +652,7 @@ func (d *SubDefaultController) CompareConfigmapByStatusAndTriggerRestart(dcr *do
 
 	// configmap changed , restart sts
 	if oldStatus.ComponentCondition.Phase == dorisv1.Available {
-		klog.Infof("CompareConfigmapByStatusAndTriggerRestart TriggerRestart %s for CRD %s , namespace: %s", componentType, dcr.Namespace, dcr.Namespace)
+		klog.Infof("CompareConfigmapAndTriggerRestart TriggerRestart %s for CRD %s , namespace: %s", componentType, dcr.Namespace, dcr.Namespace)
 		dcr.Annotations[dorisv1.GetRestartAnnotationKey(componentType)] = time.Now().Format(time.RFC3339)
 		status := dcr.GetComponentStatus(componentType)
 		status.ComponentCondition.Phase = dorisv1.Restarting

--- a/pkg/controller/sub_controller/sub_controller.go
+++ b/pkg/controller/sub_controller/sub_controller.go
@@ -630,12 +630,12 @@ func (d *SubDefaultController) BuildCoreConfigmapStatusHash(ctx context.Context,
 // 1. Compared by configmap Resolve file to map`s hash
 // 2. Add restart trigger DCR
 func (d *SubDefaultController) CompareConfigmapByStatusAndTriggerRestart(dcr *dorisv1.DorisCluster, oldStatus dorisv1.ComponentStatus, componentType dorisv1.ComponentType) {
-	oldCmHash := oldStatus.CoreConfigMapID
+	oldCmHash := oldStatus.CoreConfigMapHashValue
 	if oldCmHash == "" {
 		// oldCmHash is "" means the following situations:
 		// * First deployment: no restart is required, just skip it.
 		// * Not the first deployment, configmap was not configured: add configmap for doris, then statusfulset schedules automatic rolling restart, and this method does not need to be triggered
-		// * Not the first deployment, configmap is also configured: the operator upgrade operation is done, and 'CoreConfigMapID' was not available before. It also needs to be skipped, no restart is required, CoreConfigMapID will be modified in the subsequent 'UpdateComponentStatus' method.
+		// * Not the first deployment, configmap is also configured: the operator upgrade operation is done, and 'CoreConfigMapHashValue' was not available before. It also needs to be skipped, no restart is required, CoreConfigMapHashValue will be modified in the subsequent 'UpdateComponentStatus' method.
 		return
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #332

Related PR: #xxx

Problem Summary:

### Release note

Implement change monitoring of the configmap that mounts the doris core configuration file (fe.conf/be.conf) and cause a safe rolling restart of the corresponding node

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### How to use
1.Apply the latest CustomResourceDefinition updates with kubectl
```
kubectl create -f https://raw.githubusercontent.com/apache/doris-operator/$(curl -s https://api.github.com/repos/apache/doris-operator/releases/latest | grep tag_name | cut -d '"' -f4)/config/crd/bases/doris.apache.com_dorisclusters.yaml
```
2. Edit the DorisCluster yaml and add config as follows:
```
spec:
  enableRestartWhenConfigChange: true
```
3. when the config changes, the operator watches it and will restart the process. This ability is only for fe.conf and be.conf changed.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

