### PR TITLE
[improve](dcr) support pvc template and be multi-data disk

### DIFF
--- a/pkg/common/utils/doris/storage_conf.go
+++ b/pkg/common/utils/doris/storage_conf.go
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package doris
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// StorageRootPathInfo represents the parsed storage path information.
+type StorageRootPathInfo struct {
+	MountPath      string
+	VolumeResource string
+	Medium         string
+}
+
+// TransformStorage transforms a string of storage paths into a slice of StorageRootPathInfo.
+// Currently, both of three following formats are supported(as doris`s be.conf), remote cache is the
+// local path :
+//
+//	format 1:   /home/disk1/palo.HDD,50
+//	format 2:   /home/disk1/palo,medium:ssd,capacity:50
+//
+// remote storage :
+//
+//	format 1:   /home/disk/palo/cache,medium:remote_cache,capacity:50
+func TransformStorage(configPath string) ([]StorageRootPathInfo, error) {
+	if configPath == "" {
+		return []StorageRootPathInfo{}, nil
+	}
+
+	// Separate multiple paths by ';'
+	pathVec := strings.Split(configPath, ";")
+
+	// Remove empty elements
+	var cleanPaths []string
+	for _, p := range pathVec {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			cleanPaths = append(cleanPaths, trimmed)
+		}
+	}
+
+	if len(cleanPaths) == 0 {
+		return []StorageRootPathInfo{}, nil
+	}
+
+	// Check path uniqueness
+	uniquePaths := make(map[string]bool)
+	result := make([]StorageRootPathInfo, 0, len(cleanPaths))
+
+	for _, item := range cleanPaths {
+		info, err := parseSinglePath(item)
+		if err != nil {
+			return nil, fmt.Errorf("TransformStorage error parsing path %s: %w", item, err)
+		}
+
+		// Check path uniqueness
+		if uniquePaths[info.MountPath] {
+			return nil, fmt.Errorf("TransformStorage duplicate paths found : %s", info.MountPath)
+		}
+		uniquePaths[info.MountPath] = true
+		result = append(result, info)
+	}
+
+	return result, nil
+}
+
+// Resolving a single storage path
+func parseSinglePath(pathConfig string) (StorageRootPathInfo, error) {
+	info := StorageRootPathInfo{
+		Medium: "HDD", // default Medium is HDD
+	}
+
+	// split by ','
+	parts := strings.Split(pathConfig, ",")
+	if len(parts) == 0 || parts[0] == "" {
+		return info, fmt.Errorf("invalid storage path format: %s", pathConfig)
+	}
+
+	// path
+	rawPath := strings.TrimSpace(parts[0])
+	// remove suffix '/' , if exists
+	cleanPath := strings.TrimRight(rawPath, "/")
+	if cleanPath == "" || cleanPath[0] != '/' {
+		return info, fmt.Errorf("the path must start with '/', but got an err path: %s", rawPath)
+	}
+
+	// Check path suffix as storage medium
+	extension := filepath.Ext(cleanPath)
+	if extension != "" {
+		// Remove the leading '.' and uppercase
+		mediumType := strings.ToUpper(extension[1:])
+		// Only set if this is a valid storage type
+		if mediumType == "HDD" || mediumType == "SSD" || mediumType == "REMOTE_CACHE" {
+			info.Medium = mediumType
+			cleanPath = cleanPath[:len(cleanPath)-len(extension)]
+		}
+	}
+
+	info.MountPath = cleanPath
+
+	// Handling other attributes (e.g., capacity, medium)
+	for i := 1; i < len(parts); i++ {
+		propStr := strings.TrimSpace(parts[i])
+		if propStr == "" {
+			continue
+		}
+
+		// Parsing property format: 'property:value' or directly the value (indicating 'capacity')
+		var property, value string
+		if colonPos := strings.Index(propStr, ":"); colonPos != -1 {
+			property = strings.ToUpper(strings.TrimSpace(propStr[:colonPos]))
+			value = strings.TrimSpace(propStr[colonPos+1:])
+		} else {
+			property = "CAPACITY"
+			value = strings.TrimSpace(propStr)
+		}
+
+		// Storage properties configuration
+		switch property {
+		case "CAPACITY":
+			// Verify that the capacity is a non-negative integer
+			if value == "" {
+				return info, fmt.Errorf("parseSinglePathcapacity value cannot be empty")
+			}
+			num, err := strconv.ParseInt(value, 10, 64)
+			if err != nil || num < 0 {
+				return info, fmt.Errorf("parseSinglePath invalid capacity value: %s", value)
+			}
+			// Convert to Kubernetes quantity format (e.g., "10Gi")
+			info.VolumeResource = fmt.Sprintf("%dGi", num)
+		case "MEDIUM":
+			mediumType := strings.ToUpper(value)
+			if mediumType != "HDD" && mediumType != "SSD" && mediumType != "REMOTE_CACHE" {
+				return info, fmt.Errorf("parseSinglePath invalid storage media type: %s", value)
+			}
+			// The medium parameter takes precedence over path extension.
+			info.Medium = mediumType
+		default:
+			return info, fmt.Errorf("parseSinglePath Invalid attribute: %s", property)
+		}
+	}
+
+	return info, nil
+}

--- a/pkg/common/utils/doris/storage_conf.go
+++ b/pkg/common/utils/doris/storage_conf.go
@@ -65,6 +65,7 @@ func parseSinglePath(pathConfig string) string {
 //	["/path1", "/path2"] >> ["path1", "path2"]
 //	["/home/disk1/doris", "/home/disk2/doris"] >> ["disk1-doris", "disk2-doris"]
 //	["/home/disk1/doris", "/home/disk1/doris"] >> ["doris", "doris"]
+//	["/home/doris/disk1", "/home/doris/disk2"] >> ["disk1", "disk2"]
 //	["/home/disk1/doris", "/home/disk1/doris", "/home/disk2/doris"] >> ["disk1-doris", "disk1-doris", "disk2-doris"]
 func GetNameOfEachPath(paths []string) []string {
 	if len(paths) == 0 {

--- a/pkg/common/utils/doris/storage_conf_test.go
+++ b/pkg/common/utils/doris/storage_conf_test.go
@@ -109,6 +109,14 @@ func TestGetNameOfEachPath(t *testing.T) {
 			want:  []string{},
 		},
 		{
+			input: []string{"", "", "", ""},
+			want:  []string{"", "", "", ""},
+		},
+		{
+			input: []string{"", ""},
+			want:  []string{"", ""},
+		},
+		{
 			input: []string{"/path1"},
 			want:  []string{"path1"},
 		},
@@ -122,11 +130,11 @@ func TestGetNameOfEachPath(t *testing.T) {
 		},
 		{
 			input: []string{"/home/disk1/doris", "/home/disk2/doris"},
-			want:  []string{"disk1-doris", "disk2-doris"},
+			want:  []string{"doris", "disk2-doris"},
 		},
 		{
 			input: []string{"/home/disk1/doris", "/home/disk1/doris"},
-			want:  []string{"doris", "doris"},
+			want:  []string{"disk1-doris", "disk1-doris"},
 		},
 		{
 			input: []string{"/home/disk1/doris", "/home/disk1/doris", "/home/disk2/doris"},
@@ -134,23 +142,23 @@ func TestGetNameOfEachPath(t *testing.T) {
 		},
 		{
 			input: []string{"/home/disk1/doris", "/home/disk2/doris", "/home/disk3/doris"},
-			want:  []string{"disk1-doris", "disk2-doris", "disk3-doris"},
-		},
-		{
-			input: []string{"/home/disk1/doris", "/home/disk1/doris", "/home/disk1/doris"},
-			want:  []string{"doris", "doris", "doris"},
+			want:  []string{"doris", "disk2-doris", "disk3-doris"},
 		},
 		{
 			input: []string{"/home/disk1/doris", "/home/disk1/doris/subdir"},
-			want:  []string{"doris", "doris-subdir"},
+			want:  []string{"doris", "subdir"},
 		},
 		{
 			input: []string{"/home/disk1/doris", "/home/disk1/doris/subdir", "/home/disk1/doris/subdir/subsubdir"},
-			want:  []string{"doris", "doris-subdir", "doris-subdir-subsubdir"},
+			want:  []string{"doris", "subdir", "subsubdir"},
 		},
 		{
 			input: []string{"/home/disk1/doris", "/home/disk1/doris/subdir", "/home/disk1/doris/subdir/subsubdir", "/home/disk1/doris/subdir/subsubdir"},
-			want:  []string{"doris", "doris-subdir", "doris-subdir-subsubdir", "doris-subdir-subsubdir"},
+			want:  []string{"doris", "subdir", "subdir-subsubdir", "subdir-subsubdir"},
+		},
+		{
+			input: []string{"/home/disk1/doris", "/home/disk1/doris", "/home/disk2/doris"},
+			want:  []string{"disk1-doris", "disk1-doris", "disk2-doris"},
 		},
 	}
 

--- a/pkg/common/utils/doris/storage_conf_test.go
+++ b/pkg/common/utils/doris/storage_conf_test.go
@@ -148,7 +148,6 @@ func TestTransformStorage(t *testing.T) {
 	}
 }
 
-// 测试单个路径解析
 func TestParseSinglePath(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/common/utils/doris/storage_conf_test.go
+++ b/pkg/common/utils/doris/storage_conf_test.go
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package doris
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTransformStorage(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []StorageRootPathInfo
+		wantErr bool
+	}{
+		// Normal test
+		{
+			input: "",
+			want:  []StorageRootPathInfo{},
+		},
+		{
+			input: "/path1",
+			want: []StorageRootPathInfo{
+				{MountPath: "/path1", Medium: "HDD"},
+			},
+		},
+		{
+			input: "/path1;/path2",
+			want: []StorageRootPathInfo{
+				{MountPath: "/path1", Medium: "HDD"},
+				{MountPath: "/path2", Medium: "HDD"},
+			},
+		},
+		{
+			input: "/home/disk1/palo.HDD,50",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/palo", VolumeResource: "50Gi", Medium: "HDD"},
+			},
+		},
+		{
+			input: "/home/disk1/palo,medium:ssd,capacity:50",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/palo", VolumeResource: "50Gi", Medium: "SSD"},
+			},
+		},
+		{
+			input: "/home/disk1/palo.SSD,100;/home/disk2/palo,medium:hdd,capacity:200",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/palo", VolumeResource: "100Gi", Medium: "SSD"},
+				{MountPath: "/home/disk2/palo", VolumeResource: "200Gi", Medium: "HDD"},
+			},
+		},
+		{
+			input: "/home/disk1/palo/,capacity:50",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/palo", VolumeResource: "50Gi", Medium: "HDD"},
+			},
+		},
+		{
+			input: "/home/disk1/palo.HDD,medium:ssd",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/palo", Medium: "SSD"},
+			},
+		},
+		{
+			input: "/home/disk1/palo,capacity:50;",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/palo", VolumeResource: "50Gi", Medium: "HDD"},
+			},
+		},
+		{
+			input: " /home/disk1/palo , capacity : 50 ; /home/disk2/palo , medium : ssd ",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/palo", VolumeResource: "50Gi", Medium: "HDD"},
+				{MountPath: "/home/disk2/palo", Medium: "SSD"},
+			},
+		},
+		{
+			input: "/home/disk1/cache,medium:remote_cache,capacity:50",
+			want: []StorageRootPathInfo{
+				{MountPath: "/home/disk1/cache", VolumeResource: "50Gi", Medium: "REMOTE_CACHE"},
+			},
+		},
+
+		// Error Condition Testing
+		{
+			input:   "home/disk1/palo,capacity:50",
+			wantErr: true,
+		},
+		{
+			input:   "/home/disk1/palo,capacity:-10",
+			wantErr: true,
+		},
+		{
+			input:   "/home/disk1/palo,capacity:abc",
+			wantErr: true,
+		},
+		{
+			input:   "/home/disk1/palo,medium:invalid",
+			wantErr: true,
+		},
+		{
+			input:   "/home/disk1/palo,capacity:50;/home/disk1/palo,medium:ssd",
+			wantErr: true,
+		},
+		{
+			input:   "/home/disk1/palo,unknown:value",
+			wantErr: true,
+		},
+		{
+			input:   ",capacity:50",
+			wantErr: true,
+		},
+		{
+			input:   ";",
+			want:    []StorageRootPathInfo{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TransformStorage(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TransformStorage() error = %v, Expectation Error = %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseStorageRootPath() = %v, Expectation = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// 测试单个路径解析
+func TestParseSinglePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    StorageRootPathInfo
+		wantErr bool
+	}{
+		{
+			input: "/home/data",
+			want:  StorageRootPathInfo{MountPath: "/home/data", Medium: "HDD"},
+		},
+		{
+			input: "/home/data.HDD",
+			want:  StorageRootPathInfo{MountPath: "/home/data", Medium: "HDD"},
+		},
+		{
+			input: "/home/data.SSD",
+			want:  StorageRootPathInfo{MountPath: "/home/data", Medium: "SSD"},
+		},
+		{
+			input: "/home/data,50",
+			want:  StorageRootPathInfo{MountPath: "/home/data", VolumeResource: "50Gi", Medium: "HDD"},
+		},
+		{
+			input: "/home/data,medium:ssd,capacity:100",
+			want:  StorageRootPathInfo{MountPath: "/home/data", VolumeResource: "100Gi", Medium: "SSD"},
+		},
+		{
+			input:   "relative/path",
+			wantErr: true,
+		},
+		{
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSinglePath(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSinglePath() error = %v, Expectations Error = %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseSinglePath() = %v, Expectation = %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/common/utils/resource/configmap.go
+++ b/pkg/common/utils/resource/configmap.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"os"
 )
 
 // the fe ports key
@@ -124,7 +125,9 @@ func ResolveConfigMaps(configMaps []*corev1.ConfigMap, componentType dorisv1.Com
 			continue
 		}
 		if value, ok := configMap.Data[key]; ok {
+			os.Setenv("DORIS_HOME", getDefaultDorisHome(componentType))
 			viper.SetConfigType("properties")
+			viper.AutomaticEnv()
 			viper.ReadConfig(bytes.NewBuffer([]byte(value)))
 			return viper.AllSettings(), nil
 		}

--- a/pkg/common/utils/resource/configmap_test.go
+++ b/pkg/common/utils/resource/configmap_test.go
@@ -86,7 +86,7 @@ func Test_ResolveConfigMpas(t *testing.T) {
     JAVA_OPTS_FOR_JDK_9="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -DJDBC_MIN_POOL=1 -DJDBC_MAX_POOL=100 -DJDBC_MAX_IDLE_TIME=300000 -DJDBC_MAX_WAIT_TIME=5000"
 
     # since 1.2, the JAVA_HOME need to be set to run BE process.
-    # JAVA_HOME=/MountPath/to/jdk/
+    # JAVA_HOME=/path/to/jdk/
 
     # https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
     # https://jemalloc.net/jemalloc.3.html

--- a/pkg/common/utils/resource/configmap_test.go
+++ b/pkg/common/utils/resource/configmap_test.go
@@ -86,7 +86,7 @@ func Test_ResolveConfigMpas(t *testing.T) {
     JAVA_OPTS_FOR_JDK_9="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -DJDBC_MIN_POOL=1 -DJDBC_MAX_POOL=100 -DJDBC_MAX_IDLE_TIME=300000 -DJDBC_MAX_WAIT_TIME=5000"
 
     # since 1.2, the JAVA_HOME need to be set to run BE process.
-    # JAVA_HOME=/path/to/jdk/
+    # JAVA_HOME=/MountPath/to/jdk/
 
     # https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
     # https://jemalloc.net/jemalloc.3.html

--- a/pkg/common/utils/resource/persistent_volume_claim.go
+++ b/pkg/common/utils/resource/persistent_volume_claim.go
@@ -136,13 +136,18 @@ func GenerateEveryoneMountPathPersistentVolume(spec *dorisv1.BaseSpec, config ma
 		dataPaths = doris.ResolveStorageRootPath(dataPathValue.(string))
 	}
 
-	pathName := doris.GetNameOfEachPath(dataPaths)
-
-	for i := range dataPaths {
+	if len(dataPaths) == 1 {
 		tmp := *template.DeepCopy()
-		tmp.Name = tmp.Name + "-" + pathName[i]
-		tmp.MountPath = dataPaths[i]
+		tmp.MountPath = dataPaths[0]
 		pvs = append(pvs, tmp)
+	} else {
+		pathName := doris.GetNameOfEachPath(dataPaths)
+		for i := range dataPaths {
+			tmp := *template.DeepCopy()
+			tmp.Name = tmp.Name + "-" + pathName[i]
+			tmp.MountPath = dataPaths[i]
+			pvs = append(pvs, tmp)
+		}
 	}
 
 	return pvs, nil

--- a/pkg/common/utils/resource/persistent_volume_claim.go
+++ b/pkg/common/utils/resource/persistent_volume_claim.go
@@ -19,9 +19,13 @@ package resource
 
 import (
 	dorisv1 "github.com/apache/doris-operator/api/doris/v1"
+	"github.com/apache/doris-operator/pkg/common/utils/doris"
 	"github.com/apache/doris-operator/pkg/common/utils/hash"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"strconv"
 )
 
 var (
@@ -65,4 +69,97 @@ func buildPVCAnnotations(volume dorisv1.PersistentVolume) Annotations {
 		annotations.AddAnnotation(volume.Annotations)
 	}
 	return annotations
+}
+
+func getDefaultDorisHome(componentType dorisv1.ComponentType) string {
+	switch componentType {
+	case dorisv1.Component_FE:
+		return DEFAULT_ROOT_PATH + "/fe"
+	case dorisv1.Component_BE, dorisv1.Component_CN:
+		return DEFAULT_ROOT_PATH + "/be"
+	case dorisv1.Component_Broker:
+		return DEFAULT_ROOT_PATH + "/apache_hdfs_broker"
+	default:
+		klog.Infof("the componentType: %s have not default DORIS_HOME", componentType)
+	}
+	return ""
+}
+
+// ExplainFinalPersistentVolume is used to process the pvc template configuration in CRD.
+// The template is defined as follows:
+// - PersistentVolume.MountPath is "", it`s template configuration.
+// - PersistentVolume.MountPath is not "", it`s actual pvc configuration.
+// The Explain rules are as follows:
+// 1. Non-templated PersistentVolumes are returned directly in the result list.
+// 2. If there is a pvc template, return the actual list of pvcs after processing.
+// 3. The template needs to parse the configuration of the doris config file to create the pvc.
+// 4. If there are multiple templates, the last valid template will be used.
+func ExplainFinalPersistentVolume(spec *dorisv1.BaseSpec, config map[string]interface{}, componentType dorisv1.ComponentType) ([]dorisv1.PersistentVolume, error) {
+
+	// Only the last data pvc template configuration takes effect
+	var templet *dorisv1.PersistentVolume
+	// pvcs is the pvc that needs to be actually created, specified by the user
+	var pvs []dorisv1.PersistentVolume
+
+	for i := range spec.PersistentVolumes {
+		if spec.PersistentVolumes[i].MountPath != "" {
+			pvs = append(pvs, spec.PersistentVolumes[i])
+
+		} else {
+			//templets = &spec.PersistentVolumes[i]
+			templet = (&spec.PersistentVolumes[i]).DeepCopy()
+		}
+	}
+
+	if templet == nil {
+		return spec.PersistentVolumes, nil
+	}
+
+	// Processing pvc template
+	var dataPVName, dataPathKey, dataDefaultPath string
+	var dataPaths []doris.StorageRootPathInfo
+	dorisHome := getDefaultDorisHome(componentType)
+	switch componentType {
+	case dorisv1.Component_FE:
+		dataPathKey = "meta_dir"
+		dataDefaultPath = dorisHome + "/doris-meta"
+		dataPVName = "fe-meta"
+	case dorisv1.Component_BE, dorisv1.Component_CN:
+		dataPathKey = "storage_root_path"
+		dataDefaultPath = dorisHome + "/storage"
+		dataPVName = "be-storage"
+	default:
+		klog.Infof("ExplainFinalPersistentVolume the componentType: %s is not supported, PersistentVolume template will not work ", componentType)
+		return pvs, nil
+	}
+
+	dataPath, dataExist := config[dataPathKey]
+	if !dataExist {
+		klog.Infof("explainFinalPersistentVolume: dataPathKey '%s' not found in config, default value will effect", dataPathKey)
+		dataPaths = append(dataPaths, doris.StorageRootPathInfo{MountPath: dataDefaultPath})
+	} else {
+		var err error
+		dataPaths, err = doris.TransformStorage(dataPath.(string))
+		if err != nil {
+			klog.Errorf("ExplainFinalPersistentVolume TransformStorage failed, PersistentVolume template will not work: %s", err.Error())
+			return pvs, err
+		}
+	}
+
+	for i := range dataPaths {
+		tmp := *templet.DeepCopy()
+		tmp.Name = dataPVName + "-" + strconv.Itoa(i)
+		tmp.MountPath = dataPaths[0].MountPath
+
+		// Prioritize resource configuration in CRD.
+		// If there is no configuration in CRD, use the configuration in be.conf.
+		// If there is no setting, do not configure anything for resource.
+		if tmp.Resources.Requests.Storage().String() == "" && dataPaths[i].VolumeResource != "" {
+			tmp.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(dataPaths[i].VolumeResource)
+			tmp.Resources.Limits[corev1.ResourceStorage] = resource.MustParse(dataPaths[i].VolumeResource)
+		}
+		pvs = append(pvs, tmp)
+	}
+
+	return pvs, nil
 }

--- a/pkg/common/utils/resource/pod.go
+++ b/pkg/common/utils/resource/pod.go
@@ -386,7 +386,6 @@ func NewBaseMainContainer(dcr *v1.DorisCluster, config map[string]interface{}, c
 	default:
 	}
 
-	//fullStoragePathFromConfig(&spec, config, componentType)
 	volumeMounts := buildVolumeMounts(spec, config, componentType)
 	var envs []corev1.EnvVar
 	envs = append(envs, buildBaseEnvs(dcr)...)

--- a/pkg/common/utils/resource/pod.go
+++ b/pkg/common/utils/resource/pod.go
@@ -288,7 +288,7 @@ func constructDisaggregatedInitContainers(componentType dv1.DisaggregatedCompone
 // newVolumesFromBaseSpec return corev1.Volume build from baseSpec.
 func newVolumesFromBaseSpec(spec v1.BaseSpec, config map[string]interface{}, componentType v1.ComponentType) []corev1.Volume {
 	var volumes []corev1.Volume
-	pvs, _ := ExplainFinalPersistentVolume(&spec, config, componentType)
+	pvs, _ := GenerateEveryoneMountPathPersistentVolume(&spec, config, componentType)
 	for _, pv := range pvs {
 		var volume corev1.Volume
 		volume.Name = pv.Name
@@ -313,7 +313,7 @@ func buildVolumeMounts(spec v1.BaseSpec, config map[string]interface{}, componen
 		return volumeMounts
 	}
 
-	pvs, _ := ExplainFinalPersistentVolume(&spec, config, componentType)
+	pvs, _ := GenerateEveryoneMountPathPersistentVolume(&spec, config, componentType)
 	for _, pvs := range pvs {
 		var volumeMount corev1.VolumeMount
 		volumeMount.MountPath = pvs.MountPath

--- a/pkg/common/utils/resource/pod.go
+++ b/pkg/common/utils/resource/pod.go
@@ -91,7 +91,7 @@ var (
 	Exec      ProbeType = "exec"
 )
 
-func NewPodTemplateSpec(dcr *v1.DorisCluster, componentType v1.ComponentType) corev1.PodTemplateSpec {
+func NewPodTemplateSpec(dcr *v1.DorisCluster, config map[string]interface{}, componentType v1.ComponentType) corev1.PodTemplateSpec {
 	spec := getBaseSpecFromCluster(dcr, componentType)
 	var volumes []corev1.Volume
 	var si *v1.SystemInitialization
@@ -101,12 +101,12 @@ func NewPodTemplateSpec(dcr *v1.DorisCluster, componentType v1.ComponentType) co
 	var skipInit bool
 	switch componentType {
 	case v1.Component_FE:
-		volumes = newVolumesFromBaseSpec(dcr.Spec.FeSpec.BaseSpec)
+		volumes = newVolumesFromBaseSpec(dcr.Spec.FeSpec.BaseSpec, config, componentType)
 		si = dcr.Spec.FeSpec.BaseSpec.SystemInitialization
 		dcrAffinity = dcr.Spec.FeSpec.BaseSpec.Affinity
 		SecurityContext = dcr.Spec.FeSpec.BaseSpec.SecurityContext
 	case v1.Component_BE:
-		volumes = newVolumesFromBaseSpec(dcr.Spec.BeSpec.BaseSpec)
+		volumes = newVolumesFromBaseSpec(dcr.Spec.BeSpec.BaseSpec, config, componentType)
 		si = dcr.Spec.BeSpec.BaseSpec.SystemInitialization
 		dcrAffinity = dcr.Spec.BeSpec.BaseSpec.Affinity
 		SecurityContext = dcr.Spec.BeSpec.BaseSpec.SecurityContext
@@ -286,9 +286,10 @@ func constructDisaggregatedInitContainers(componentType dv1.DisaggregatedCompone
 }
 
 // newVolumesFromBaseSpec return corev1.Volume build from baseSpec.
-func newVolumesFromBaseSpec(spec v1.BaseSpec) []corev1.Volume {
+func newVolumesFromBaseSpec(spec v1.BaseSpec, config map[string]interface{}, componentType v1.ComponentType) []corev1.Volume {
 	var volumes []corev1.Volume
-	for _, pv := range spec.PersistentVolumes {
+	pvs, _ := ExplainFinalPersistentVolume(&spec, config, componentType)
+	for _, pv := range pvs {
 		var volume corev1.Volume
 		volume.Name = pv.Name
 		volume.VolumeSource = corev1.VolumeSource{
@@ -303,7 +304,7 @@ func newVolumesFromBaseSpec(spec v1.BaseSpec) []corev1.Volume {
 }
 
 // buildVolumeMounts construct all volumeMounts contains default volumeMounts if persistentVolumes not definition.
-func buildVolumeMounts(spec v1.BaseSpec, componentType v1.ComponentType) []corev1.VolumeMount {
+func buildVolumeMounts(spec v1.BaseSpec, config map[string]interface{}, componentType v1.ComponentType) []corev1.VolumeMount {
 	var volumeMounts []corev1.VolumeMount
 	_, volumeMounts = appendPodInfoVolumesVolumeMounts(nil, volumeMounts)
 	if len(spec.PersistentVolumes) == 0 {
@@ -312,7 +313,8 @@ func buildVolumeMounts(spec v1.BaseSpec, componentType v1.ComponentType) []corev
 		return volumeMounts
 	}
 
-	for _, pvs := range spec.PersistentVolumes {
+	pvs, _ := ExplainFinalPersistentVolume(&spec, config, componentType)
+	for _, pvs := range pvs {
 		var volumeMount corev1.VolumeMount
 		volumeMount.MountPath = pvs.MountPath
 		volumeMount.Name = pvs.Name
@@ -384,7 +386,8 @@ func NewBaseMainContainer(dcr *v1.DorisCluster, config map[string]interface{}, c
 	default:
 	}
 
-	volumeMounts := buildVolumeMounts(spec, componentType)
+	//fullStoragePathFromConfig(&spec, config, componentType)
+	volumeMounts := buildVolumeMounts(spec, config, componentType)
 	var envs []corev1.EnvVar
 	envs = append(envs, buildBaseEnvs(dcr)...)
 	envs = append(envs, buildKerberosEnv(dcr.Spec.KerberosInfo, config, componentType)...)

--- a/pkg/common/utils/resource/pod_test.go
+++ b/pkg/common/utils/resource/pod_test.go
@@ -28,7 +28,8 @@ import (
 
 func Test_NewPodTemplateSpec(t *testing.T) {
 	for _, ct := range []v1.ComponentType{"fe", "be", "cn", "broker"} {
-		pt := NewPodTemplateSpec(dcr, ct)
+		config := map[string]interface{}{}
+		pt := NewPodTemplateSpec(dcr, config, ct)
 		t.Log(pt)
 	}
 }

--- a/pkg/common/utils/resource/statefulset.go
+++ b/pkg/common/utils/resource/statefulset.go
@@ -47,7 +47,7 @@ func NewStatefulSet(dcr *v1.DorisCluster, config map[string]interface{}, compone
 
 	var volumeClaimTemplates []corev1.PersistentVolumeClaim
 
-	pvs, _ := ExplainFinalPersistentVolume(bSpec, config, componentType)
+	pvs, _ := GenerateEveryoneMountPathPersistentVolume(bSpec, config, componentType)
 	for _, vct := range pvs {
 		pvc := corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/common/utils/resource/statefulset_test.go
+++ b/pkg/common/utils/resource/statefulset_test.go
@@ -27,7 +27,7 @@ import (
 func Test_NewStatefulset(t *testing.T) {
 	cts := []v1.ComponentType{v1.Component_FE, v1.Component_BE, v1.Component_CN, v1.Component_Broker}
 	for _, ct := range cts {
-		st := NewStatefulSet(dcr, ct)
+		st := NewStatefulSet(dcr, map[string]interface{}{}, ct)
 		t.Log(st)
 	}
 }

--- a/pkg/controller/sub_controller/be/controller.go
+++ b/pkg/controller/sub_controller/be/controller.go
@@ -99,7 +99,7 @@ func (be *Controller) Sync(ctx context.Context, dcr *v1.DorisCluster) error {
 		return err
 	}
 
-	st := be.buildBEStatefulSet(dcr)
+	st := be.buildBEStatefulSet(dcr, config)
 	if !be.PrepareReconcileResources(ctx, dcr, v1.Component_BE) {
 		klog.Infof("be controller sync preparing resource for reconciling namespace %s name %s!", dcr.Namespace, dcr.Name)
 		return nil

--- a/pkg/controller/sub_controller/be/pod.go
+++ b/pkg/controller/sub_controller/be/pod.go
@@ -29,8 +29,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (be *Controller) buildBEPodTemplateSpec(dcr *v1.DorisCluster) corev1.PodTemplateSpec {
-	podTemplateSpec := resource.NewPodTemplateSpec(dcr, v1.Component_BE)
+func (be *Controller) buildBEPodTemplateSpec(dcr *v1.DorisCluster, config map[string]interface{}) corev1.PodTemplateSpec {
+	podTemplateSpec := resource.NewPodTemplateSpec(dcr, config, v1.Component_BE)
 	//if enable fe affinity, should not add fe antiAffinity and set the weight of affinity less than be antiAffinity.
 	if dcr.Spec.BeSpec.EnableFeAffinity == true {
 		be.addFeAffinity(&podTemplateSpec)
@@ -84,7 +84,7 @@ func (be *Controller) addFeAntiAffinity(tplSpec *corev1.PodTemplateSpec) {
 		preferedScheduleTerm)
 }
 
-//aff fe affinity for be, wish the fe and be will 1:1 deployed in same node.
+// aff fe affinity for be, wish the fe and be will 1:1 deployed in same node.
 func (be *Controller) addFeAffinity(tplSpec *corev1.PodTemplateSpec) {
 	pst := corev1.WeightedPodAffinityTerm{
 		// the weight of be antiAffinity with be is 20.
@@ -93,9 +93,9 @@ func (be *Controller) addFeAffinity(tplSpec *corev1.PodTemplateSpec) {
 			LabelSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{
-						Key: v1.ComponentLabelKey,
+						Key:      v1.ComponentLabelKey,
 						Operator: metav1.LabelSelectorOpIn,
-						Values: []string{string(v1.Component_FE)},
+						Values:   []string{string(v1.Component_FE)},
 					},
 				},
 			},

--- a/pkg/controller/sub_controller/be/pod.go
+++ b/pkg/controller/sub_controller/be/pod.go
@@ -84,7 +84,7 @@ func (be *Controller) addFeAntiAffinity(tplSpec *corev1.PodTemplateSpec) {
 		preferedScheduleTerm)
 }
 
-// aff fe affinity for be, wish the fe and be will 1:1 deployed in same node.
+// add fe affinity for be, wish the fe and be will 1:1 deployed in same node.
 func (be *Controller) addFeAffinity(tplSpec *corev1.PodTemplateSpec) {
 	pst := corev1.WeightedPodAffinityTerm{
 		// the weight of be antiAffinity with be is 20.

--- a/pkg/controller/sub_controller/be/pod_test.go
+++ b/pkg/controller/sub_controller/be/pod_test.go
@@ -57,9 +57,8 @@ func Test_buildBEPodTemplateSpec(t *testing.T) {
 	}
 
 	be := &Controller{}
-	be.buildBEPodTemplateSpec(dcr)
+	be.buildBEPodTemplateSpec(dcr, map[string]interface{}{})
 }
-
 
 func Test_buildBEPodTemplateSpecWithFEAffinity(t *testing.T) {
 	dcrJsonStr := `{
@@ -97,5 +96,5 @@ func Test_buildBEPodTemplateSpecWithFEAffinity(t *testing.T) {
 	}
 
 	be := &Controller{}
-	be.buildBEPodTemplateSpec(dcr)
+	be.buildBEPodTemplateSpec(dcr, map[string]interface{}{})
 }

--- a/pkg/controller/sub_controller/be/statefulset.go
+++ b/pkg/controller/sub_controller/be/statefulset.go
@@ -23,8 +23,8 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 )
 
-func (be *Controller) buildBEStatefulSet(dcr *v1.DorisCluster) appv1.StatefulSet {
-	st := resource.NewStatefulSet(dcr, v1.Component_BE)
-	st.Spec.Template = be.buildBEPodTemplateSpec(dcr)
+func (be *Controller) buildBEStatefulSet(dcr *v1.DorisCluster, config map[string]interface{}) appv1.StatefulSet {
+	st := resource.NewStatefulSet(dcr, config, v1.Component_BE)
+	st.Spec.Template = be.buildBEPodTemplateSpec(dcr, config)
 	return st
 }

--- a/pkg/controller/sub_controller/be/statefulset_test.go
+++ b/pkg/controller/sub_controller/be/statefulset_test.go
@@ -65,5 +65,5 @@ func Test_buildBEStatefulSet(t *testing.T) {
 		t.Errorf("Test_buildBEStatefulSet unmarshal failed, err=%s", err.Error())
 	}
 	bc := &Controller{}
-	bc.buildBEStatefulSet(dcr)
+	bc.buildBEStatefulSet(dcr, map[string]interface{}{})
 }

--- a/pkg/controller/sub_controller/broker/controller.go
+++ b/pkg/controller/sub_controller/broker/controller.go
@@ -81,7 +81,7 @@ func (bk *Controller) Sync(ctx context.Context, dcr *v1.DorisCluster) error {
 		return err
 	}
 
-	st := bk.buildBKStatefulSet(dcr)
+	st := bk.buildBKStatefulSet(dcr, config)
 	if err = k8s.ApplyStatefulSet(ctx, bk.K8sclient, &st, func(new *appv1.StatefulSet, est *appv1.StatefulSet) bool {
 		// if have restart annotation, we should exclude the interference for comparison.
 		return resource.StatefulSetDeepEqual(new, est, false)

--- a/pkg/controller/sub_controller/broker/pod.go
+++ b/pkg/controller/sub_controller/broker/pod.go
@@ -26,8 +26,8 @@ import (
 	"strconv"
 )
 
-func (broker *Controller) buildBrokerPodTemplateSpec(dcr *v1.DorisCluster) corev1.PodTemplateSpec {
-	podTemplateSpec := resource.NewPodTemplateSpec(dcr, v1.Component_Broker)
+func (broker *Controller) buildBrokerPodTemplateSpec(dcr *v1.DorisCluster, config map[string]interface{}) corev1.PodTemplateSpec {
+	podTemplateSpec := resource.NewPodTemplateSpec(dcr, config, v1.Component_Broker)
 	var containers []corev1.Container
 	broker.addDefaultBorkerPodAffinity(dcr, &podTemplateSpec)
 	containers = append(containers, podTemplateSpec.Spec.Containers...)

--- a/pkg/controller/sub_controller/broker/statefulset.go
+++ b/pkg/controller/sub_controller/broker/statefulset.go
@@ -23,8 +23,8 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 )
 
-func (broker *Controller) buildBKStatefulSet(dcr *v1.DorisCluster) appv1.StatefulSet {
-	st := resource.NewStatefulSet(dcr, v1.Component_Broker)
-	st.Spec.Template = broker.buildBrokerPodTemplateSpec(dcr)
+func (broker *Controller) buildBKStatefulSet(dcr *v1.DorisCluster, config map[string]interface{}) appv1.StatefulSet {
+	st := resource.NewStatefulSet(dcr, config, v1.Component_Broker)
+	st.Spec.Template = broker.buildBrokerPodTemplateSpec(dcr, config)
 	return st
 }

--- a/pkg/controller/sub_controller/cn/controller.go
+++ b/pkg/controller/sub_controller/cn/controller.go
@@ -91,7 +91,7 @@ func (cn *Controller) Sync(ctx context.Context, dcr *dorisv1.DorisCluster) error
 			svc.Name, svc.Namespace, dcr.Name, err.Error())
 		return err
 	}
-	cnStatefulSet := cn.buildCnStatefulSet(dcr)
+	cnStatefulSet := cn.buildCnStatefulSet(dcr, config)
 	if !cn.PrepareReconcileResources(ctx, dcr, dorisv1.Component_CN) {
 		klog.Infof("cn controller sync preparing resource for reconciling namespace %s name %s!", dcr.Namespace, dcr.Name)
 		return nil

--- a/pkg/controller/sub_controller/cn/pod.go
+++ b/pkg/controller/sub_controller/cn/pod.go
@@ -26,8 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cn *Controller) buildCnPodTemplateSpec(dcr *v1.DorisCluster) corev1.PodTemplateSpec {
-	podTemplateSpec := resource.NewPodTemplateSpec(dcr, v1.Component_CN)
+func (cn *Controller) buildCnPodTemplateSpec(dcr *v1.DorisCluster, config map[string]interface{}) corev1.PodTemplateSpec {
+	podTemplateSpec := resource.NewPodTemplateSpec(dcr, config, v1.Component_CN)
 	var containers []corev1.Container
 	containers = append(containers, podTemplateSpec.Spec.Containers...)
 	cnContainer := cn.cnContainer(dcr)

--- a/pkg/controller/sub_controller/cn/statefulset.go
+++ b/pkg/controller/sub_controller/cn/statefulset.go
@@ -23,8 +23,8 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 )
 
-func (cn *Controller) buildCnStatefulSet(dcr *v1.DorisCluster) appv1.StatefulSet {
-	statefulSet := resource.NewStatefulSet(dcr, v1.Component_CN)
-	statefulSet.Spec.Template = cn.buildCnPodTemplateSpec(dcr)
+func (cn *Controller) buildCnStatefulSet(dcr *v1.DorisCluster, config map[string]interface{}) appv1.StatefulSet {
+	statefulSet := resource.NewStatefulSet(dcr, config, v1.Component_CN)
+	statefulSet.Spec.Template = cn.buildCnPodTemplateSpec(dcr, config)
 	return statefulSet
 }

--- a/pkg/controller/sub_controller/events.go
+++ b/pkg/controller/sub_controller/events.go
@@ -31,6 +31,7 @@ const (
 	StatefulSetNotExist     = "StatefulSetNotExist"
 	AutoScalerDeleteFailed  = "AutoScalerDeleteFailed"
 	ComponentImageUpdate    = "ComponentImageUpdate"
+	PVCExplainFailed        = "PVCExplainFailed"
 	PVCListFailed           = "PVCListFailed"
 	PVCUpdate               = "PVCUpdated"
 	PVCUpdateFailed         = "PVCUpdateFailed"

--- a/pkg/controller/sub_controller/fe/controller.go
+++ b/pkg/controller/sub_controller/fe/controller.go
@@ -128,7 +128,7 @@ func (fc *Controller) Sync(ctx context.Context, cluster *v1.DorisCluster) error 
 		return err
 	}
 
-	st := fc.buildFEStatefulSet(cluster)
+	st := fc.buildFEStatefulSet(cluster, config)
 	if err = k8s.ApplyStatefulSet(ctx, fc.K8sclient, &st, func(new *appv1.StatefulSet, old *appv1.StatefulSet) bool {
 		fc.RestrictConditionsEqual(new, old)
 		return resource.StatefulSetDeepEqual(new, old, false)

--- a/pkg/controller/sub_controller/fe/pod.go
+++ b/pkg/controller/sub_controller/fe/pod.go
@@ -18,7 +18,6 @@
 package fe
 
 import (
-	"context"
 	"strconv"
 
 	v1 "github.com/apache/doris-operator/api/doris/v1"
@@ -26,11 +25,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (fc *Controller) buildFEPodTemplateSpec(dcr *v1.DorisCluster) corev1.PodTemplateSpec {
-	podTemplateSpec := resource.NewPodTemplateSpec(dcr, v1.Component_FE)
+func (fc *Controller) buildFEPodTemplateSpec(dcr *v1.DorisCluster, config map[string]interface{}) corev1.PodTemplateSpec {
+	podTemplateSpec := resource.NewPodTemplateSpec(dcr, config, v1.Component_FE)
 	var containers []corev1.Container
 	//containers = append(containers, podTemplateSpec.Spec.Containers...)
-	config, _ := fc.GetConfig(context.Background(), &dcr.Spec.FeSpec.ConfigMapInfo, dcr.Namespace, v1.Component_FE)
 	feContainer := fc.feContainer(dcr, config)
 	containers = append(containers, feContainer)
 	containers = resource.ApplySecurityContext(containers, dcr.Spec.FeSpec.ContainerSecurityContext)

--- a/pkg/controller/sub_controller/fe/pod_test.go
+++ b/pkg/controller/sub_controller/fe/pod_test.go
@@ -65,5 +65,5 @@ func Test_buildFEPodTemplateSpec(t *testing.T) {
 		t.Errorf("Test_buildBEStatefulSet unmarshal failed, err=%s", err.Error())
 	}
 	fc := &Controller{}
-	fc.buildFEPodTemplateSpec(dcr)
+	fc.buildFEPodTemplateSpec(dcr, map[string]interface{}{})
 }

--- a/pkg/controller/sub_controller/fe/statefulset.go
+++ b/pkg/controller/sub_controller/fe/statefulset.go
@@ -23,8 +23,8 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 )
 
-func (fc *Controller) buildFEStatefulSet(dcr *v1.DorisCluster) appv1.StatefulSet {
-	st := resource.NewStatefulSet(dcr, v1.Component_FE)
-	st.Spec.Template = fc.buildFEPodTemplateSpec(dcr)
+func (fc *Controller) buildFEStatefulSet(dcr *v1.DorisCluster, config map[string]interface{}) appv1.StatefulSet {
+	st := resource.NewStatefulSet(dcr, config, v1.Component_FE)
+	st.Spec.Template = fc.buildFEPodTemplateSpec(dcr, config)
 	return st
 }

--- a/pkg/controller/sub_controller/fe/statefulset_test.go
+++ b/pkg/controller/sub_controller/fe/statefulset_test.go
@@ -65,5 +65,5 @@ func Test_buildFEStatefulSet(t *testing.T) {
 		t.Errorf("Test_buildBEStatefulSet unmarshal failed, err=%s", err.Error())
 	}
 	fc := &Controller{}
-	fc.buildFEStatefulSet(dcr)
+	fc.buildFEStatefulSet(dcr, map[string]interface{}{})
 }

--- a/pkg/controller/sub_controller/sub_controller.go
+++ b/pkg/controller/sub_controller/sub_controller.go
@@ -189,9 +189,9 @@ func (d *SubDefaultController) GetFinalPersistentVolumes(ctx context.Context, dc
 		return nil, err
 	}
 
-	volume, err := resource.ExplainFinalPersistentVolume(&baseSpec, config, componentType)
+	volume, err := resource.GenerateEveryoneMountPathPersistentVolume(&baseSpec, config, componentType)
 	if err != nil {
-		klog.Errorf("GetFinalPersistentVolumes ExplainFinalPersistentVolume failed, namespace: %s,err: %s \n", dcr.Namespace, err.Error())
+		klog.Errorf("GetFinalPersistentVolumes GenerateEveryoneMountPathPersistentVolume failed, namespace: %s,err: %s \n", dcr.Namespace, err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Improved the flexibility of DCR PVC configuration, configured the storage path according to fe.conf/be.conf, and implemented the configuration of be multi-data disk from ‘storage_root_path’.

`storage_root_path=${DORIS_HOME}/aaa;${DORIS_HOME}/sss;${DORIS_HOME}/ddd`

The above configuration allows Doris be to mount three data disks as data storage media according to the following configuration

```yaml
  beSpec:
    replicas: 3
    persistentVolumes:
    - mountPath: /opt/apache-doris/be/log
      name: be-log
      persistentVolumeClaimSpec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
    - name: be-storage
      persistentVolumeClaimSpec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 10Gi
```

operator constructs the following pvcs:
```
root@VM-0-12-ubuntu:~/k8s_test# kubectl get pvc  -ndoris
NAME                                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
be-log-doriscluster-sample-be-0           Bound    pvc-65c07d0b-a1a8-4f35-9478-9482937893e4   1Gi        RWO            standard       2m2s
be-log-doriscluster-sample-be-1           Bound    pvc-febc6396-5f7c-42ed-833c-7019ca8063aa   1Gi        RWO            standard       2m2s
be-log-doriscluster-sample-be-2           Bound    pvc-1b4cc269-24d3-42b3-b4ac-2abb78d4b20d   1Gi        RWO            standard       2m2s
be-storage-aaa-doriscluster-sample-be-0   Bound    pvc-85061456-cdfd-43aa-b78c-4d3fe8b0b0b1   10Gi       RWO            standard       2m2s
be-storage-aaa-doriscluster-sample-be-1   Bound    pvc-ea57bc54-39eb-48bf-ab28-0b81342cd3bc   10Gi       RWO            standard       2m2s
be-storage-aaa-doriscluster-sample-be-2   Bound    pvc-c42faa27-06a9-4da3-b79d-e43a76fd1a52   10Gi       RWO            standard       2m2s
be-storage-ddd-doriscluster-sample-be-0   Bound    pvc-0a5cd375-0150-4920-ae3b-899ec7b43174   10Gi       RWO            standard       2m2s
be-storage-ddd-doriscluster-sample-be-1   Bound    pvc-f22006dd-361d-4f68-970a-a4393e6b086a   10Gi       RWO            standard       2m2s
be-storage-ddd-doriscluster-sample-be-2   Bound    pvc-a513a340-a94d-4922-9d42-736653b580c1   10Gi       RWO            standard       2m2s
be-storage-sss-doriscluster-sample-be-0   Bound    pvc-91fafd6f-7330-4a0b-b01c-b05ea11fee60   10Gi       RWO            standard       2m2s
be-storage-sss-doriscluster-sample-be-1   Bound    pvc-f88b1bcb-b989-4d50-8b07-cc4e0db2e715   10Gi       RWO            standard       2m2s
be-storage-sss-doriscluster-sample-be-2   Bound    pvc-4db82cd9-0e06-4d9e-b507-87e601108fbf   10Gi       RWO            standard       2m2s
```

This change is fully compatible with the previous configuration method, and the previous configuration rules can still be used.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

