### PR TITLE
[feature](ddc) enable DDC workload group

### DIFF
--- a/api/disaggregated/v1/types.go
+++ b/api/disaggregated/v1/types.go
@@ -89,6 +89,13 @@ type ComputeGroup struct {
 	//the unique identifier of compute group, first register in fe will use UniqueId as cluster name.
 	UniqueId string `json:"uniqueId"`
 
+	// EnableWorkloadGroup is a switch that determines whether the doris cluster enables the workload group.
+	// Default value is 'false'.
+	// Enabling it means that the container must be started in privileged mode.
+	// Please confirm whether the host machine and k8s cluster allow it.
+	// Doris workloadgroup reference document: https://doris.apache.org/docs/admin-manual/resource-admin/workload-group
+	EnableWorkloadGroup bool `json:"enableWorkloadGroup,omitempty"`
+
 	CommonSpec `json:",inline"`
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Supports enabling workload groups for compute groups like DCR
Note: Need to update the latest doris be image, built-in scripts have important logic. [doris-50247](https://github.com/apache/doris/pull/50247)

```yaml
  computeGroups:
    - uniqueId: test1
      enableWorkloadGroup: true
      replicas: 3
      image: apache/doris:be-{version}
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

