### PR TITLE
[improve](ddc)Enable ddc skip default systeminit check

### DIFF
--- a/api/disaggregated/v1/types.go
+++ b/api/disaggregated/v1/types.go
@@ -90,6 +90,12 @@ type ComputeGroup struct {
 	UniqueId string `json:"uniqueId"`
 
 	CommonSpec `json:",inline"`
+
+	// SkipDefaultSystemInit is a switch that skips the default initialization and is used to set the default environment configuration required by the doris BE node.
+	// Default value is 'false'.
+	// Default System Init means that the container must be started in privileged mode.
+	// Default System Init configuration is implemented through the initContainers of the pod, so changes to this configuration may be ignored by k8s when it is not the first deployment.
+	SkipDefaultSystemInit bool `json:"skipDefaultSystemInit,omitempty"`
 }
 
 type CommonSpec struct {

--- a/config/crd/bases/crds.yaml
+++ b/config/crd/bases/crds.yaml
@@ -11361,6 +11361,13 @@ spec:
                     serviceAccount:
                       description: serviceAccount for compute node access cloud service.
                       type: string
+                    skipDefaultSystemInit:
+                      description: |-
+                        SkipDefaultSystemInit is a switch that skips the default initialization and is used to set the default environment configuration required by the doris BE node.
+                        Default value is 'false'.
+                        Default System Init means that the container must be started in privileged mode.
+                        Default System Init configuration is implemented through the initContainers of the pod, so changes to this configuration may be ignored by k8s when it is not the first deployment.
+                      type: boolean
                     startTimeout:
                       description: pod start timeout, unit is second
                       format: int32

--- a/config/crd/bases/disaggregated.cluster.doris.com_dorisdisaggregatedclusters.yaml
+++ b/config/crd/bases/disaggregated.cluster.doris.com_dorisdisaggregatedclusters.yaml
@@ -2234,6 +2234,13 @@ spec:
                     serviceAccount:
                       description: serviceAccount for compute node access cloud service.
                       type: string
+                    skipDefaultSystemInit:
+                      description: |-
+                        SkipDefaultSystemInit is a switch that skips the default initialization and is used to set the default environment configuration required by the doris BE node.
+                        Default value is 'false'.
+                        Default System Init means that the container must be started in privileged mode.
+                        Default System Init configuration is implemented through the initContainers of the pod, so changes to this configuration may be ignored by k8s when it is not the first deployment.
+                      type: boolean
                     startTimeout:
                       description: pod start timeout, unit is second
                       format: int32

--- a/pkg/common/utils/resource/pod.go
+++ b/pkg/common/utils/resource/pod.go
@@ -190,7 +190,7 @@ func NewPodTemplateSpec(dcr *v1.DorisCluster, config map[string]interface{}, com
 }
 
 // for disaggregated cluster.
-func NewPodTemplateSpecWithCommonSpec(skipInit bool, cs *dv1.CommonSpec, componentType dv1.DisaggregatedComponentType) corev1.PodTemplateSpec {
+func NewPodTemplateSpecWithCommonSpec(skipDefaultInit bool, cs *dv1.CommonSpec, componentType dv1.DisaggregatedComponentType) corev1.PodTemplateSpec {
 	var vs []corev1.Volume
 	si := cs.SystemInitialization
 	var defaultInitContainers []corev1.Container
@@ -214,7 +214,7 @@ func NewPodTemplateSpecWithCommonSpec(skipInit bool, cs *dv1.CommonSpec, compone
 			Volumes:            vs,
 		},
 	}
-	constructDisaggregatedInitContainers(skipInit, componentType, &pts.Spec, si)
+	constructDisaggregatedInitContainers(skipDefaultInit, componentType, &pts.Spec, si)
 	return pts
 }
 
@@ -264,7 +264,7 @@ func constructInitContainers(skipInit bool, componentType v1.ComponentType, podS
 	podSpec.InitContainers = append(podSpec.InitContainers, defaultInitContains...)
 }
 
-func constructDisaggregatedInitContainers(skipInit bool, componentType dv1.DisaggregatedComponentType, podSpec *corev1.PodSpec, si *dv1.SystemInitialization) {
+func constructDisaggregatedInitContainers(skipDefaultInit bool, componentType dv1.DisaggregatedComponentType, podSpec *corev1.PodSpec, si *dv1.SystemInitialization) {
 	initImage := DEFAULT_INIT_IMAGE
 	var defaultInitContains []corev1.Container
 	if si != nil {
@@ -287,7 +287,7 @@ func constructDisaggregatedInitContainers(skipInit bool, componentType dv1.Disag
 	}
 
 	// the init containers have sequence，should confirm use initial is always in the first priority.
-	if !skipInit && componentType == dv1.DisaggregatedBE {
+	if !skipDefaultInit && componentType == dv1.DisaggregatedBE {
 		podSpec.InitContainers = append(podSpec.InitContainers, constructBeDefaultInitContainer(initImage))
 	}
 	podSpec.InitContainers = append(podSpec.InitContainers, defaultInitContains...)

--- a/pkg/common/utils/resource/pod.go
+++ b/pkg/common/utils/resource/pod.go
@@ -190,7 +190,7 @@ func NewPodTemplateSpec(dcr *v1.DorisCluster, config map[string]interface{}, com
 }
 
 // for disaggregated cluster.
-func NewPodTemplateSpecWithCommonSpec(cs *dv1.CommonSpec, componentType dv1.DisaggregatedComponentType) corev1.PodTemplateSpec {
+func NewPodTemplateSpecWithCommonSpec(skipInit bool, cs *dv1.CommonSpec, componentType dv1.DisaggregatedComponentType) corev1.PodTemplateSpec {
 	var vs []corev1.Volume
 	si := cs.SystemInitialization
 	var defaultInitContainers []corev1.Container
@@ -214,7 +214,7 @@ func NewPodTemplateSpecWithCommonSpec(cs *dv1.CommonSpec, componentType dv1.Disa
 			Volumes:            vs,
 		},
 	}
-	constructDisaggregatedInitContainers(componentType, &pts.Spec, si)
+	constructDisaggregatedInitContainers(skipInit, componentType, &pts.Spec, si)
 	return pts
 }
 
@@ -264,7 +264,7 @@ func constructInitContainers(skipInit bool, componentType v1.ComponentType, podS
 	podSpec.InitContainers = append(podSpec.InitContainers, defaultInitContains...)
 }
 
-func constructDisaggregatedInitContainers(componentType dv1.DisaggregatedComponentType, podSpec *corev1.PodSpec, si *dv1.SystemInitialization) {
+func constructDisaggregatedInitContainers(skipInit bool, componentType dv1.DisaggregatedComponentType, podSpec *corev1.PodSpec, si *dv1.SystemInitialization) {
 	initImage := DEFAULT_INIT_IMAGE
 	var defaultInitContains []corev1.Container
 	if si != nil {
@@ -287,7 +287,7 @@ func constructDisaggregatedInitContainers(componentType dv1.DisaggregatedCompone
 	}
 
 	// the init containers have sequence，should confirm use initial is always in the first priority.
-	if componentType == dv1.DisaggregatedBE {
+	if !skipInit && componentType == dv1.DisaggregatedBE {
 		podSpec.InitContainers = append(podSpec.InitContainers, constructBeDefaultInitContainer(initImage))
 	}
 	podSpec.InitContainers = append(podSpec.InitContainers, defaultInitContains...)

--- a/pkg/common/utils/resource/pod_test.go
+++ b/pkg/common/utils/resource/pod_test.go
@@ -122,7 +122,7 @@ func Test_NewPodTemplateSpecWithCommonSpec(t *testing.T) {
 	tm[dv1.DisaggregatedMS] = mcs
 
 	for dct, cs := range tm {
-		pts := NewPodTemplateSpecWithCommonSpec(cs, dct)
+		pts := NewPodTemplateSpecWithCommonSpec(false, cs, dct)
 		t.Log(pts)
 	}
 }

--- a/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/statefulset.go
@@ -86,7 +86,7 @@ func (dfc *DisaggregatedFEController) getFEPodLabels(ddc *v1.DorisDisaggregatedC
 }
 
 func (dfc *DisaggregatedFEController) NewPodTemplateSpec(ddc *v1.DorisDisaggregatedCluster, confMap map[string]interface{}) corev1.PodTemplateSpec {
-	pts := resource.NewPodTemplateSpecWithCommonSpec(&ddc.Spec.FeSpec.CommonSpec, v1.DisaggregatedFE)
+	pts := resource.NewPodTemplateSpecWithCommonSpec(false, &ddc.Spec.FeSpec.CommonSpec, v1.DisaggregatedFE)
 	//pod template metadata.
 	labels := dfc.getFEPodLabels(ddc)
 	pts.Labels = labels

--- a/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset.go
@@ -88,7 +88,7 @@ func (dms *DisaggregatedMSController) newStatefulset(ddc *v1.DorisDisaggregatedC
 }
 
 func (dms *DisaggregatedMSController) NewPodTemplateSpec(ddc *v1.DorisDisaggregatedCluster, selector map[string]string, confMap map[string]interface{}) corev1.PodTemplateSpec {
-	pts := resource.NewPodTemplateSpecWithCommonSpec(&ddc.Spec.MetaService.CommonSpec, v1.DisaggregatedMS)
+	pts := resource.NewPodTemplateSpecWithCommonSpec(false, &ddc.Spec.MetaService.CommonSpec, v1.DisaggregatedMS)
 	//pod template metadata.
 	func() {
 		l := (resource.Labels)(selector)


### PR DESCRIPTION
### What problem does this PR solve?

CRD adds new parameter configuration. If you need to skip the default initialization system check to avoid BE environment restrictions, you need to add `skipDefaultSystemInit` the following configuration: 

```yaml
  computeGroups:
    - uniqueId: test1
      skipDefaultSystemInit: true
      replicas: 3
      image: apache/doris:be-3.0.5
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

