### PR TITLE
🎯 fix(disaggregated_cluster): missing podinfo volume mount

### DIFF
--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
@@ -153,12 +153,10 @@ func (dcgs *DisaggregatedComputeGroupsController) NewCGContainer(ddc *dv1.DorisD
 	resource.BuildDisaggregatedProbe(&c, &cg.CommonSpec, dv1.DisaggregatedBE)
 	_, vms, _ := dcgs.BuildVolumesVolumeMountsAndPVCs(cvs, dv1.DisaggregatedBE, &cg.CommonSpec)
 	_, cmvms := dcgs.BuildDefaultConfigMapVolumesVolumeMounts(cg.ConfigMaps)
-	c.VolumeMounts = vms
-	if c.VolumeMounts == nil {
-		c.VolumeMounts = cmvms
-	} else {
-		c.VolumeMounts = append(c.VolumeMounts, cmvms...)
+	if vms != nil {
+		c.VolumeMounts = append(c.VolumeMounts, vms...)
 	}
+	c.VolumeMounts = append(c.VolumeMounts, cmvms...)
 
 	// add basic auth secret volumeMount
 	if ddc.Spec.AuthSecret != "" {

--- a/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/statefulset.go
@@ -144,12 +144,10 @@ func (dfc *DisaggregatedFEController) NewFEContainer(ddc *v1.DorisDisaggregatedC
 	resource.BuildDisaggregatedProbe(&c, &ddc.Spec.FeSpec.CommonSpec, v1.DisaggregatedFE)
 	_, vms, _ := dfc.BuildVolumesVolumeMountsAndPVCs(cvs, v1.DisaggregatedFE, &ddc.Spec.FeSpec.CommonSpec)
 	_, cmvms := dfc.BuildDefaultConfigMapVolumesVolumeMounts(ddc.Spec.FeSpec.ConfigMaps)
-	c.VolumeMounts = vms
-	if c.VolumeMounts == nil {
-		c.VolumeMounts = cmvms
-	} else {
-		c.VolumeMounts = append(c.VolumeMounts, cmvms...)
+	if vms != nil {
+		c.VolumeMounts = append(c.VolumeMounts, vms...)
 	}
+	c.VolumeMounts = append(c.VolumeMounts, cmvms...)
 
 	// add basic auth secret volumeMount
 	if ddc.Spec.AuthSecret != "" {

--- a/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset.go
@@ -131,12 +131,10 @@ func (dms *DisaggregatedMSController) NewMSContainer(ddc *v1.DorisDisaggregatedC
 	resource.BuildDisaggregatedProbe(&c, &ddc.Spec.MetaService.CommonSpec, v1.DisaggregatedMS)
 	_, vms, _ := dms.BuildVolumesVolumeMountsAndPVCs(cvs, v1.DisaggregatedMS, &ddc.Spec.MetaService.CommonSpec)
 	_, cmvms := dms.BuildDefaultConfigMapVolumesVolumeMounts(ddc.Spec.MetaService.ConfigMaps)
-	c.VolumeMounts = vms
-	if c.VolumeMounts == nil {
-		c.VolumeMounts = cmvms
-	} else {
-		c.VolumeMounts = append(c.VolumeMounts, cmvms...)
+	if vms != nil {
+		c.VolumeMounts = append(c.VolumeMounts, vms...)
 	}
+	c.VolumeMounts = append(c.VolumeMounts, cmvms...)
 
 	if len(ddc.Spec.MetaService.Secrets) != 0 {
 		_, secretVolumeMounts := resource.GetMultiSecretVolumeAndVolumeMountWithCommonSpec(&ddc.Spec.MetaService.CommonSpec)


### PR DESCRIPTION
### What problem does this PR solve?

Currently, the volume mount from `NewContainerWithCommonSpec` be override by `c.VolumeMounts = vms`. Therefore, the podinfo volume mount is missing.