### PR TITLE
[Bug] fix issue #441 use clearErr not reconErr when clearUnusedResources() returned 

### DIFF
--- a/pkg/controller/disaggregated_cluster_controller.go
+++ b/pkg/controller/disaggregated_cluster_controller.go
@@ -21,6 +21,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"time"
+
 	dv1 "github.com/apache/doris-operator/api/disaggregated/v1"
 	"github.com/apache/doris-operator/pkg/common/utils/hash"
 	sc "github.com/apache/doris-operator/pkg/controller/sub_controller"
@@ -35,7 +38,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	controller_builder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +45,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 )
 
 var (
@@ -214,7 +215,7 @@ func (dc *DisaggregatedClusterReconciler) Reconcile(ctx context.Context, req rec
 	// clear unused resources.
 	clearRes, clearErr := dc.clearUnusedResources(ctx, &ddc)
 	if clearErr != nil {
-		msg = msg + reconErr.Error()
+		msg = msg + clearErr.Error()
 	}
 
 	if !clearRes.IsZero() {
@@ -344,7 +345,7 @@ func (dc *DisaggregatedClusterReconciler) updateObjectORStatus(ctx context.Conte
 
 }
 
-func(dc *DisaggregatedClusterReconciler) clearReconcileAnnotations(ddc *dv1.DorisDisaggregatedCluster) {
+func (dc *DisaggregatedClusterReconciler) clearReconcileAnnotations(ddc *dv1.DorisDisaggregatedCluster) {
 	if len(ddc.Annotations) == 0 {
 		return
 	}


### PR DESCRIPTION
should use clearErr not reconErr in pkg/controller/disaggregated_cluster_controller.go

### What problem does this PR solve?

Issue Number: close #441 

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

