### PR TITLE
[fix] runmode=debug not work

### DIFF
--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
@@ -151,14 +151,16 @@ func (dcgs *DisaggregatedComputeGroupsController) NewCGContainer(ddc *dv1.DorisD
 	}
 
 	resource.BuildDisaggregatedProbe(&c, &cg.CommonSpec, dv1.DisaggregatedBE)
-	_, vms, _ := dcgs.BuildVolumesVolumeMountsAndPVCs(cvs, dv1.DisaggregatedBE, &cg.CommonSpec)
-	_, cmvms := dcgs.BuildDefaultConfigMapVolumesVolumeMounts(cg.ConfigMaps)
-	c.VolumeMounts = vms
+
 	if c.VolumeMounts == nil {
-		c.VolumeMounts = cmvms
-	} else {
-		c.VolumeMounts = append(c.VolumeMounts, cmvms...)
+		c.VolumeMounts = []corev1.VolumeMount{}
 	}
+	_, vms, _ := dcgs.BuildVolumesVolumeMountsAndPVCs(cvs, dv1.DisaggregatedBE, &cg.CommonSpec)
+	if vms != nil {
+		c.VolumeMounts = append(c.VolumeMounts, vms...)
+	}
+	_, cmvms := dcgs.BuildDefaultConfigMapVolumesVolumeMounts(cg.ConfigMaps)
+	c.VolumeMounts = append(c.VolumeMounts, cmvms...)
 
 	// add basic auth secret volumeMount
 	if ddc.Spec.AuthSecret != "" {
@@ -210,6 +212,7 @@ func (dcgs *DisaggregatedComputeGroupsController) newSpecificEnvs(ddc *dv1.Doris
 	return cgEnvs
 }
 
-func(dcgs *DisaggregatedComputeGroupsController) useNewDefaultValuesInStatefulset(st *appv1.StatefulSet) {
+func (dcgs *DisaggregatedComputeGroupsController) useNewDefaultValuesInStatefulset(st *appv1.StatefulSet) {
 	resource.UseNewDefaultInitContainerImage(&st.Spec.Template)
 }
+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #443 

Problem Summary:
When the compute node crash, and then set run mode to debug with the  following commands.

``` bash
kubectl annotate pod hello-simple-doris-cg2-0 selectdb.com.doris/runmode=debug
kubectl annotate pod hello-simple-doris-cg2-0 apache.com.doris/runmode=debug
```

But the be process still startup which is unexpected.

Because the following /etc/podinfo is not mounted, and then the doris-debug command failed to check.

<img width="1200" height="230" alt="image" src="https://github.com/user-attachments/assets/60b6c343-c5a8-4c2d-9b1c-1bf6c1771bb6" />


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

