### PR TITLE
[fix] compile error and add ddc for makefile

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -19,7 +19,8 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/doris.selectdb.com_dorisclusters.yaml
+# - bases/doris.selectdb.com_dorisclusters.yaml
+- bases/crds.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,7 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
### What problem does this PR solve?

Compile error, because the go.sum oauth2 not cleaned

```
admin DorisOperator % make manifests
test -s /Users/admin/Workspace/Codes/Operatores/DorisOperator/bin/controller-gen && /Users/admin/Workspace/Codes/Operatores/DorisOperator/bin/controller-gen --version | grep -q v0.16.4 || \
        GOBIN=/Users/admin/Workspace/Codes/Operatores/DorisOperator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.4
/Users/admin/Workspace/Codes/Operatores/DorisOperator/bin/controller-gen rbac:roleName=manager-doris crd:generateEmbeddedObjectMeta=true webhook paths="./api/doris/..." output:crd:artifacts:config=config/crd/bases
/opt/golang/vendor/pkg/mod/k8s.io/client-go@v0.32.0/transport/round_trippers.go:28:2: missing go.sum entry for module providing package golang.org/x/oauth2 (imported by k8s.io/client-go/transport); to add:
        go get k8s.io/client-go/transport@v0.32.0
Error: not all generators ran successfully
run `controller-gen rbac:roleName=manager-doris crd:generateEmbeddedObjectMeta=true webhook paths=./api/doris/... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen rbac:roleName=manager-doris crd:generateEmbeddedObjectMeta
=true webhook paths=./api/doris/... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [manifests] Error 1
```

for `make install` command, only doris cluster crd installed, but ddc not.

Some tips:
make install should change the following line to create sub-command for first time, and change back when update. https://github.com/apache/doris-operator/blob/e511317e9430ff7f348839b8251e59f07ed7b51b/Makefile#L159
or you have the following error when create at first time.

```
Resource: "apiextensions.k8s.io/v1, Resource=customresourcedefinitions", GroupVersionKind: "apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"
Name: "dorisclusters.doris.selectdb.com", Namespace: ""
for: "STDIN": error when patching "STDIN": CustomResourceDefinition.apiextensions.k8s.io "dorisclusters.doris.selectdb.com" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "dorisdisaggregatedclusters.disaggregated.cluster.doris.com" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
make: *** [install] Error 1
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason, just for developing <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

