### PR TITLE
helm/doris-operator: add support for deploy resources

### DIFF
--- a/helm-charts/doris-operator/templates/deployment.yaml
+++ b/helm-charts/doris-operator/templates/deployment.yaml
@@ -118,10 +118,12 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          # TODO(user): Configure the resources accordingly based on the project requirements.
-          # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
           resources:
+            {{- if .Values.dorisOperator.resources }}
+            {{- toYaml .Values.dorisOperator.resources | nindent 12 }}
+            {{ else }}
             {{- include "operator.default.resources" . | indent 8 }}
+            {{- end }}
           volumeMounts:
             - mountPath:  /tmp/k8s-webhook-server/serving-certs
               name: cert


### PR DESCRIPTION
### What problem does this PR solve?
Add support to setup resources in the dosris-operator helm chart.

Problem Summary:


The chart exposes resources configuration fields in `values.yaml` under `dorisOperator.resources`, but the Deployment template always used the "hard-coded" default values instead of the user-provided overrides.


This issue can be reproduced as follows:

```bash
ᐅ  helm template doris-operator ./doris-operator \
--set dorisOperator.resources.requests.memory=50Mi \
--set dorisOperator.resources.requests.cpu=200m \
| yq 'select(.kind == "Deployment") .spec.template.spec.containers[0].resources'

requests:
  cpu: 2
  memory: 4Gi
limits:
  cpu: 2
  memory: 4Gi
```
The values coming from `values.yaml` are ignored, and the Deployment always renders the default resources.

After applying the template changes included in this PR, Helm correctly renders the user-configured resources:

```bash
ᐅ  helm template doris-operator ./doris-operator \
--set dorisOperator.resources.requests.memory=50Mi \
--set dorisOperator.resources.requests.cpu=200m \   
| yq 'select(.kind == "Deployment") .spec.template.spec.containers[0].resources'

requests:
  cpu: 200m
  memory: 50Mi
```

This confirms that the chart now properly respects user-defined resource settings from values.yaml


### Release note
Add support to setup resources in the dosris-operator helm chart.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

