### PR TITLE
[feat] helm-charts: add support for secrets

### DIFF
--- a/helm-charts/doris/templates/doriscluster.yaml
+++ b/helm-charts/doris/templates/doriscluster.yaml
@@ -116,6 +116,10 @@ spec:
     hostAliases:
     {{- toYaml .Values.feSpec.hostAliases | nindent 4 }}
     {{- end }}
+    {{- if .Values.feSpec.secrets }}
+    secrets:
+    {{- toYaml .Values.feSpec.secrets | nindent 4 }}
+    {{- end }}
     {{- if .Values.feSpec.persistentVolumeClaim }}
     persistentVolumes:
     {{- template "doriscluster.fe.pvc" . }}
@@ -200,6 +204,10 @@ spec:
     {{- if .Values.beSpec.hostAliases }}
     hostAliases:
     {{- toYaml .Values.beSpec.hostAliases | nindent 4 }}
+    {{- end }}
+    {{- if .Values.beSpec.secrets }}
+    secrets:
+    {{- toYaml .Values.beSpec.secrets | nindent 4 }}
     {{- end }}
     {{- if .Values.beSpec.persistentVolumeClaim }}
     persistentVolumes:
@@ -289,7 +297,10 @@ spec:
     hostAliases:
     {{- toYaml .Values.cnSpec.hostAliases | nindent 4 }}
     {{- end }}
-
+    {{- if .Values.cnSpec.secrets }}
+    secrets:
+    {{- toYaml .Values.cnSpec.secrets | nindent 4 }}
+    {{- end }}
     {{- if .Values.cnSpec.persistentVolumeClaim }}
     persistentVolumes:
     {{- template "doriscluster.cn.pvc" . }}
@@ -370,6 +381,10 @@ spec:
     {{- if .Values.brokerSpec.hostAliases }}
     hostAliases:
     {{- toYaml .Values.brokerSpec.hostAliases | nindent 4 }}
+    {{- end }}
+    {{- if .Values.brokerSpec.secrets }}
+    secrets:
+    {{- toYaml .Values.brokerSpec.secrets | nindent 4 }}
     {{- end }}
     {{- if .Values.brokerSpec.persistentVolumeClaim }}
     persistentVolumes:

--- a/helm-charts/doris/values.yaml
+++ b/helm-charts/doris/values.yaml
@@ -202,6 +202,13 @@ feSpec:
   # - ip: "127.0.0.2"
   #   hostnames:
   #   - "hostname2"
+  
+  # secrets allows mounting Kubernetes secrets into the pods
+  # Each secret must have a secretName (name of the secret in Kubernetes) and optionally a mountPath
+  secrets: []
+  # - secretName: my-secret
+  #   mountPath: /etc/doris
+  
   persistentVolumeClaim: {}
     # meta volume, mountPath is /opt/apache-doris/fe/doris-meta
     # metaPersistentVolume:
@@ -369,6 +376,13 @@ beSpec:
   # - ip: "127.0.0.2"
   #   hostnames:
   #   - "hostname2"
+  
+  # secrets allows mounting Kubernetes secrets into the pods
+  # Each secret must have a secretName (name of the secret in Kubernetes) and optionally a mountPath
+  secrets: []
+  # - secretName: my-secret
+  #   mountPath: /etc/doris
+  
   persistentVolumeClaim: {}
     # data volume, mountPath is /opt/apache-doris/be/storage
     # dataPersistentVolume:
@@ -537,6 +551,13 @@ cnSpec:
   # - ip: "127.0.0.2"
   #   hostnames:
   #   - "hostname2"
+  
+  # secrets allows mounting Kubernetes secrets into the pods
+  # Each secret must have a secretName (name of the secret in Kubernetes) and optionally a mountPath
+  secrets: []
+  # - secretName: my-secret
+  #   mountPath: /etc/doris
+  
   persistentVolumeClaim: {}
     # data volume, mountPath is /opt/apache-doris/be/storage
     # dataPersistentVolume:
@@ -698,6 +719,13 @@ brokerSpec:
   # - ip: "127.0.0.2"
   #   hostnames:
   #   - "hostname2"
+  
+  # secrets allows mounting Kubernetes secrets into the pods
+  # Each secret must have a secretName (name of the secret in Kubernetes) and optionally a mountPath
+  secrets: []
+  # - secretName: my-secret
+  #   mountPath: /etc/doris
+  
   persistentVolumeClaim: {}
     # logs volume, mountPath is /opt/apache-doris/apache_hdfs_broker/log
     # logsPersistentVolume:


### PR DESCRIPTION
### What problem does this PR solve?

The `secrets` field defined in the DorisCluster specification was not being handled when deploying via Helm chart. This PR add support for the `secrets` field in the Helm chart template and values file for all component specs.

Related issue: #242 

Added `secrets` configuration section with documentation and examples for each component spec:
- Default empty array: `secrets: []`
- Example commented configuration showing how to use secrets:
```yaml
feSpec:
  secrets:
    - secretName: my-secret
      mountPath: /etc/doris
```
