### PR TITLE
feat: add topologySpreadConstraints support and respect user-provided…

### DIFF
--- a/api/disaggregated/v1/types.go
+++ b/api/disaggregated/v1/types.go
@@ -177,6 +177,11 @@ type CommonSpec struct {
 	//+optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	// (Optional) TopologySpreadConstraints describes how a group of pods ought to spread across topology
+	// domains. Scheduler will schedule pods in a way which abides by the constraints.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
 	// export service for accessing from outside k8s.
 	Service *ExportService `json:"service,omitempty"`
 

--- a/api/doris/v1/types.go
+++ b/api/doris/v1/types.go
@@ -245,6 +245,11 @@ type BaseSpec struct {
 	//+optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	// (Optional) TopologySpreadConstraints describes how a group of pods ought to spread across topology
+	// domains. Scheduler will schedule pods in a way which abides by the constraints.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
 	//+optional
 	// podLabels for user selector or classify pods
 	PodLabels map[string]string `json:"podLabels,omitempty"`

--- a/pkg/controller/sub_controller/disaggregated_subcontroller.go
+++ b/pkg/controller/sub_controller/disaggregated_subcontroller.go
@@ -189,22 +189,12 @@ func (d *DisaggregatedSubDefaultController) BuildDefaultConfigMapVolumesVolumeMo
 }
 
 func (d *DisaggregatedSubDefaultController) ConstructDefaultAffinity(matchKey, value string, ddcAffinity *corev1.Affinity) *corev1.Affinity {
-	affinity := d.newDefaultAffinity(matchKey, value)
-
-	if ddcAffinity == nil {
-		return affinity
+	// If user provides affinity, respect it completely without injecting defaults
+	if ddcAffinity != nil {
+		return ddcAffinity.DeepCopy()
 	}
-
-	ddcPodAntiAffinity := ddcAffinity.PodAntiAffinity
-	if ddcPodAntiAffinity != nil {
-		affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = ddcPodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-		affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, ddcPodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
-	}
-
-	affinity.NodeAffinity = ddcAffinity.NodeAffinity
-	affinity.PodAffinity = ddcAffinity.PodAffinity
-
-	return affinity
+	// Only apply defaults when user hasn't specified any affinity
+	return d.newDefaultAffinity(matchKey, value)
 }
 
 func (d *DisaggregatedSubDefaultController) newDefaultAffinity(matchKey, value string) *corev1.Affinity {


### PR DESCRIPTION
… affinity

This commit introduces two related scheduling enhancements:

1. Add topologySpreadConstraints field to BaseSpec (aggregated cluster) and CommonSpec (disaggregated cluster) for more flexible pod distribution control.

2. Change affinity behavior to fully respect user-provided configuration:
   - If user provides affinity, use it as-is without injecting defaults
   - Only apply default soft podAntiAffinity when user hasn't specified any affinity

This allows users to configure scenarios like hard zone spreading with soft node spreading using topologySpreadConstraints, which was not possible before.

Files modified:
- api/doris/v1/types.go: Add TopologySpreadConstraints to BaseSpec
- api/disaggregated/v1/types.go: Add TopologySpreadConstraints to CommonSpec
- pkg/common/utils/resource/pod.go: Pass through TopologySpreadConstraints, simplify constructAffinity to respect user config
- pkg/controller/sub_controller/disaggregated_subcontroller.go: Simplify ConstructDefaultAffinity to respect user config

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

TopologySpreadConstraints are not added to the operator, i use these for my infrastructure.  please add them

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [X] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [] Other reason <!-- Add your reason?  -->
        
This change was tested by applying the patch, building a new operator and deploying in my AKS cluster.

- Behavior changed:
    - [ ] No.
    - [X] Yes. 
    
    In my infrastructure i use topology spread constraints to keep pods scheduled on different nodes and AZ's the operator does not support this.  This PR adds this ability if they are not set nothing changes
   ```
    topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: kubernetes.io/hostname
      whenUnsatisfiable: ScheduleAnyway
      labelSelector:
        matchLabels:
          app.doris.disaggregated.type: ms

    - maxSkew: 2
      topologyKey: topology.kubernetes.io/zone
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          app.doris.disaggregated.type: ms
```

This PR also keeps the podaffinity if set by the configuration.  I had affinity set to "RequiredDuringSchedulingIgnoredDuringExecution" but its being changed by the operator to "PreferredDuringSchedulingIgnoredDuringExecution"  

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

