### PR TITLE
enhancement: set TerminationGracePeriodSeconds with value in be.conf

### DIFF
--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
@@ -119,6 +119,7 @@ func (dcgs *DisaggregatedComputeGroupsController) NewPodTemplateSpec(ddc *dv1.Do
 	dcgs.DisaggregatedSubDefaultController.AddClusterSpecForPodTemplate(dv1.DisaggregatedBE, cvs, &ddc.Spec, &pts)
 	cgUniqueId := selector[dv1.DorisDisaggregatedComputeGroupUniqueId]
 	pts.Spec.Affinity = dcgs.ConstructDefaultAffinity(dv1.DorisDisaggregatedComputeGroupUniqueId, cgUniqueId, pts.Spec.Affinity)
+	dcgs.DisaggregatedSubDefaultController.AddTerminationGracePeriodSeconds(cg, ddc, &pts)
 
 	return pts
 }

--- a/pkg/controller/sub_controller/disaggregated_subcontroller.go
+++ b/pkg/controller/sub_controller/disaggregated_subcontroller.go
@@ -609,7 +609,7 @@ func (d *DisaggregatedSubDefaultController) getEmptyDirVolumesVolumeMounts(confM
 }
 
 // this function is a compensation, because the DownwardAPI annotations and labels are not mount in pod, so this function amends。
-func(d *DisaggregatedSubDefaultController) AddDownwardAPI(st *appv1.StatefulSet) {
+func (d *DisaggregatedSubDefaultController) AddDownwardAPI(st *appv1.StatefulSet) {
 	t := &st.Spec.Template
 	for index, _ := range t.Spec.Containers {
 		if t.Spec.Containers[index].Name == resource.DISAGGREGATED_FE_MAIN_CONTAINER_NAME || t.Spec.Containers[index].Name == resource.DISAGGREGATED_BE_MAIN_CONTAINER_NAME ||
@@ -802,4 +802,13 @@ func (d *DisaggregatedSubDefaultController) FindSecretTLSConfig(feConfMap map[st
 	}
 
 	return tlsConfig, secretName
+}
+
+// Only configure the TerminationGracePeriodSeconds when grace_shutdown_wait_seconds configured in be.conf
+func (dcgs *DisaggregatedSubDefaultController) AddTerminationGracePeriodSeconds(cg *v1.ComputeGroup, ddc *v1.DorisDisaggregatedCluster, pts *corev1.PodTemplateSpec) {
+	config := dcgs.GetConfigValuesFromConfigMaps(ddc.Namespace, resource.BE_RESOLVEKEY, cg.CommonSpec.ConfigMaps)
+	seconds := resource.GetTerminationGracePeriodSeconds(config)
+	if seconds > 0 {
+		pts.Spec.TerminationGracePeriodSeconds = &seconds
+	}
 }


### PR DESCRIPTION
`TerminationGracePeriodSeconds` are set by operator for dcr BEs, but not for ddc compute group BEs. 

This PR set compute group BE Pod template's `TerminationGracePeriodSeconds` with config value `grace_shutdown_wait_seconds` in be.conf

### What problem does this PR solve?

Issue Number: close #475

Related PR: N/A

Problem Summary:

### Release note

graceful shutdown for disaggregated doris backends

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

