### PR TITLE
[branch-25.8] Stabilize DDC graceful rollout pod templates

### DIFF
--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller.go
@@ -212,8 +212,6 @@ func (dcgs *DisaggregatedComputeGroupsController) reconcileStatefulset(ctx conte
 
 	var est appv1.StatefulSet
 	if err := dcgs.K8sclient.Get(ctx, types.NamespacedName{Namespace: st.Namespace, Name: st.Name}, &est); apierrors.IsNotFound(err) {
-		// add downlaodAPI volume Mounts
-		dcgs.DisaggregatedSubDefaultController.AddDownwardAPI(st)
 		//if err = k8s.CreateClientObject(ctx, dcgs.K8sclient, st); err != nil {
 		//	klog.Errorf("disaggregatedComputeGroupsController reconcileStatefulset create statefulset namespace=%s name=%s failed, err=%s", st.Namespace, st.Name, err.Error())
 		//	return &sc.Event{Type: sc.EventWarning, Reason: sc.CGCreateResourceFailed, Message: err.Error()}, err
@@ -292,7 +290,6 @@ func (dcgs *DisaggregatedComputeGroupsController) reconcileStatefulset(ctx conte
 			ddc_annos := (resource.Annotations)(cluster.Annotations)
 			msUniqueIdKey := strings.ToLower(fmt.Sprintf(dv1.UpdateStatefulsetName, cluster.GetCGStatefulsetName(cg)))
 			ddc_annos.Add(msUniqueIdKey, "true")
-			dcgs.DisaggregatedSubDefaultController.AddDownwardAPI(new)
 		}
 		return businessEqual && gracefulStatefulSetControlEqual(new, est)
 

--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset.go
@@ -172,10 +172,10 @@ func (dcgs *DisaggregatedComputeGroupsController) NewCGContainer(ddc *dv1.DorisD
 	resource.BuildDisaggregatedProbe(&c, &cg.CommonSpec, dv1.DisaggregatedBE)
 	_, vms, _ := dcgs.BuildVolumesVolumeMountsAndPVCs(cvs, dv1.DisaggregatedBE, &cg.CommonSpec)
 	_, cmvms := dcgs.BuildDefaultConfigMapVolumesVolumeMounts(cg.ConfigMaps)
-	c.VolumeMounts = vms
-	if c.VolumeMounts == nil {
-		c.VolumeMounts = cmvms
-	} else {
+	if len(vms) != 0 {
+		c.VolumeMounts = append(c.VolumeMounts, vms...)
+	}
+	if len(cmvms) != 0 {
 		c.VolumeMounts = append(c.VolumeMounts, cmvms...)
 	}
 	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset_test.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/statefulset_test.go
@@ -84,6 +84,21 @@ func Test_NewPodTemplateSpec_TerminationGracePeriodSeconds(t *testing.T) {
 	if !foundRuntimeMount {
 		t.Fatalf("expected compute container to mount %q at %q", gracefulRuntimeVolumeName, gracefulRuntimeMountPath)
 	}
+	foundPodInfoMount := false
+	for _, c := range pts.Spec.Containers {
+		if c.Name != resource.DISAGGREGATED_BE_MAIN_CONTAINER_NAME {
+			continue
+		}
+		for _, vm := range c.VolumeMounts {
+			if vm.Name == resource.POD_INFO_VOLUME_NAME && vm.MountPath == resource.POD_INFO_PATH {
+				foundPodInfoMount = true
+				break
+			}
+		}
+	}
+	if !foundPodInfoMount {
+		t.Fatalf("expected compute container to keep podinfo mount %q at %q", resource.POD_INFO_VOLUME_NAME, resource.POD_INFO_PATH)
+	}
 }
 
 func Test_newSpecificEnvs_AlwaysUseFQDNHostType(t *testing.T) {

--- a/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/controller.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/controller.go
@@ -275,9 +275,6 @@ func (dfc *DisaggregatedFEController) initialFEStatus(ddc *v1.DorisDisaggregated
 func (dfc *DisaggregatedFEController) reconcileStatefulset(ctx context.Context, st *appv1.StatefulSet, cluster *v1.DorisDisaggregatedCluster) (*sc.Event, error) {
 	var est appv1.StatefulSet
 	if err := dfc.K8sclient.Get(ctx, types.NamespacedName{Namespace: st.Namespace, Name: st.Name}, &est); apierrors.IsNotFound(err) {
-		// add downlaodAPI volume Mounts
-		dfc.DisaggregatedSubDefaultController.AddDownwardAPI(st)
-
 		if err = k8s.CreateClientObject(ctx, dfc.K8sclient, st); err != nil {
 			klog.Errorf("disaggregatedFEController reconcileStatefulset create statefulset namespace=%s name=%s failed, err=%s", st.Namespace, st.Name, err.Error())
 			return &sc.Event{Type: sc.EventWarning, Reason: sc.FECreateResourceFailed, Message: err.Error()}, err
@@ -333,7 +330,6 @@ func (dfc *DisaggregatedFEController) reconcileStatefulset(ctx context.Context, 
 			ddc_annos := (resource.Annotations)(cluster.Annotations)
 			msUniqueIdKey := strings.ToLower(fmt.Sprintf(v1.UpdateStatefulsetName, cluster.GetFEStatefulsetName()))
 			ddc_annos.Add(msUniqueIdKey, "true")
-			dfc.DisaggregatedSubDefaultController.AddDownwardAPI(st)
 		}
 		return equal
 	}); err != nil {

--- a/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe/statefulset.go
@@ -138,10 +138,10 @@ func (dfc *DisaggregatedFEController) NewFEContainer(ddc *v1.DorisDisaggregatedC
 	resource.BuildDisaggregatedProbe(&c, &ddc.Spec.FeSpec.CommonSpec, v1.DisaggregatedFE)
 	_, vms, _ := dfc.BuildVolumesVolumeMountsAndPVCs(cvs, v1.DisaggregatedFE, &ddc.Spec.FeSpec.CommonSpec)
 	_, cmvms := dfc.BuildDefaultConfigMapVolumesVolumeMounts(ddc.Spec.FeSpec.ConfigMaps)
-	c.VolumeMounts = vms
-	if c.VolumeMounts == nil {
-		c.VolumeMounts = cmvms
-	} else {
+	if len(vms) != 0 {
+		c.VolumeMounts = append(c.VolumeMounts, vms...)
+	}
+	if len(cmvms) != 0 {
 		c.VolumeMounts = append(c.VolumeMounts, cmvms...)
 	}
 

--- a/pkg/controller/sub_controller/disaggregated_cluster/metaservice/controller.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/metaservice/controller.go
@@ -196,9 +196,6 @@ func (dms *DisaggregatedMSController) Sync(ctx context.Context, obj client.Objec
 func (dms *DisaggregatedMSController) reconcileStatefulset(ctx context.Context, st *appv1.StatefulSet, ddc *v1.DorisDisaggregatedCluster) (*sc.Event, error) {
 	var est appv1.StatefulSet
 	if err := dms.K8sclient.Get(ctx, types.NamespacedName{Namespace: st.Namespace, Name: st.Name}, &est); apierrors.IsNotFound(err) {
-		// add downlaodAPI volume Mounts
-		dms.DisaggregatedSubDefaultController.AddDownwardAPI(st)
-
 		if err = k8s.CreateClientObject(ctx, dms.K8sclient, st); err != nil {
 			klog.Errorf("dms controller reconcileStatefulset create statefulset namespace=%s name=%s failed, err=%s", st.Namespace, st.Name, err.Error())
 			return &sc.Event{Type: sc.EventWarning, Reason: sc.CGCreateResourceFailed, Message: err.Error()}, err
@@ -227,7 +224,6 @@ func (dms *DisaggregatedMSController) reconcileStatefulset(ctx context.Context, 
 			ddc_annos := (resource.Annotations)(ddc.Annotations)
 			msUniqueIdKey := strings.ToLower(fmt.Sprintf(v1.UpdateStatefulsetName, ddc.GetMSStatefulsetName()))
 			ddc_annos.Add(msUniqueIdKey, "true")
-			dms.DisaggregatedSubDefaultController.AddDownwardAPI(st)
 		}
 
 		return equal

--- a/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset.go
@@ -121,10 +121,10 @@ func (dms *DisaggregatedMSController) NewMSContainer(ddc *v1.DorisDisaggregatedC
 	resource.BuildDisaggregatedProbe(&c, &ddc.Spec.MetaService.CommonSpec, v1.DisaggregatedMS)
 	_, vms, _ := dms.BuildVolumesVolumeMountsAndPVCs(cvs, v1.DisaggregatedMS, &ddc.Spec.MetaService.CommonSpec)
 	_, cmvms := dms.BuildDefaultConfigMapVolumesVolumeMounts(ddc.Spec.MetaService.ConfigMaps)
-	c.VolumeMounts = vms
-	if c.VolumeMounts == nil {
-		c.VolumeMounts = cmvms
-	} else {
+	if len(vms) != 0 {
+		c.VolumeMounts = append(c.VolumeMounts, vms...)
+	}
+	if len(cmvms) != 0 {
 		c.VolumeMounts = append(c.VolumeMounts, cmvms...)
 	}
 

--- a/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset_test.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/metaservice/statefulset_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package disaggregated_fe
+package metaservice
 
 import (
 	"testing"
@@ -26,33 +26,31 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func Test_NewPodTemplateSpec_TerminationGracePeriodSeconds(t *testing.T) {
+func TestNewPodTemplateSpec_KeepsPodInfoMount(t *testing.T) {
 	ddc := &dv1.DorisDisaggregatedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-ddc",
 			Namespace: "default",
 		},
 		Spec: dv1.DorisDisaggregatedClusterSpec{
-			FeSpec: dv1.FeSpec{
+			MetaService: dv1.MetaService{
 				CommonSpec: dv1.CommonSpec{
 					Replicas: pointer.Int32(1),
-					Image:    "selectdb/doris.fe-ubuntu:latest",
+					Image:    "selectdb/doris.ms-ubuntu:latest",
+				},
+				FDB: dv1.FDB{
+					Address: "127.0.0.1:4500",
 				},
 			},
 		},
 	}
 
-	dfc := &DisaggregatedFEController{}
-	pts := dfc.NewPodTemplateSpec(ddc, map[string]interface{}{})
-	if pts.Spec.TerminationGracePeriodSeconds == nil {
-		t.Fatalf("expected FE terminationGracePeriodSeconds")
-	}
-	if *pts.Spec.TerminationGracePeriodSeconds != resource.DEFAULT_FE_TERMINATION_GRACE_PERIOD_SECONDS {
-		t.Errorf("expected FE terminationGracePeriodSeconds=%d, got %d", resource.DEFAULT_FE_TERMINATION_GRACE_PERIOD_SECONDS, *pts.Spec.TerminationGracePeriodSeconds)
-	}
+	dms := &DisaggregatedMSController{}
+	pts := dms.NewPodTemplateSpec(ddc, map[string]string{}, map[string]interface{}{})
+
 	foundPodInfoMount := false
 	for _, c := range pts.Spec.Containers {
-		if c.Name != resource.DISAGGREGATED_FE_MAIN_CONTAINER_NAME {
+		if c.Name != resource.DISAGGREGATED_MS_MAIN_CONTAINER_NAME {
 			continue
 		}
 		for _, vm := range c.VolumeMounts {
@@ -63,6 +61,6 @@ func Test_NewPodTemplateSpec_TerminationGracePeriodSeconds(t *testing.T) {
 		}
 	}
 	if !foundPodInfoMount {
-		t.Fatalf("expected FE container to keep podinfo mount %q at %q", resource.POD_INFO_VOLUME_NAME, resource.POD_INFO_PATH)
+		t.Fatalf("expected metaservice container to keep podinfo mount %q at %q", resource.POD_INFO_VOLUME_NAME, resource.POD_INFO_PATH)
 	}
 }

--- a/pkg/controller/sub_controller/disaggregated_subcontroller.go
+++ b/pkg/controller/sub_controller/disaggregated_subcontroller.go
@@ -700,19 +700,6 @@ func (d *DisaggregatedSubDefaultController) getEmptyDirVolumesVolumeMounts(confM
 	}
 }
 
-// this function is a compensation, because the DownwardAPI annotations and labels are not mount in pod, so this function amends。
-func (d *DisaggregatedSubDefaultController) AddDownwardAPI(st *appv1.StatefulSet) {
-	t := &st.Spec.Template
-	for index, _ := range t.Spec.Containers {
-		if t.Spec.Containers[index].Name == resource.DISAGGREGATED_FE_MAIN_CONTAINER_NAME || t.Spec.Containers[index].Name == resource.DISAGGREGATED_BE_MAIN_CONTAINER_NAME ||
-			t.Spec.Containers[index].Name == resource.DISAGGREGATED_MS_MAIN_CONTAINER_NAME {
-			_, d_v_m := resource.GetPodInfoVolumesVolumeMounts()
-			t.Spec.Containers[index].VolumeMounts = append(t.Spec.Containers[index].VolumeMounts, d_v_m...)
-			break
-		}
-	}
-}
-
 func (d *DisaggregatedSubDefaultController) getBEEmptyDirVolumesVolumeMounts(confMap map[string]interface{}) ([]corev1.Volume, []corev1.VolumeMount) {
 	vs := []corev1.Volume{
 		{


### PR DESCRIPTION
## Summary
- Backport DDC graceful rollout hardening to the 25.8 branch
- Keep DDC compute group StatefulSets on OnDelete and drive BE replacement through the operator-controlled graceful rollout flow
- Preserve default podinfo mounts in DDC FE/BE/MS containers and remove the old DownwardAPI compensation path to avoid pod template drift
- Add tests for podinfo mounts and rollout state handling

## Tests
- go test ./pkg/controller/sub_controller/disaggregated_cluster/computegroups ./pkg/controller/sub_controller/disaggregated_cluster/disaggregated_fe ./pkg/controller/sub_controller/disaggregated_cluster/metaservice ./pkg/common/utils/resource
