### PR TITLE
fix: reject ddc compute group storage template changes

### DIFF
--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller.go
@@ -36,7 +36,9 @@ import (
 	sc "github.com/apache/doris-operator/pkg/controller/sub_controller"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -242,6 +244,12 @@ func (dcgs *DisaggregatedComputeGroupsController) reconcileStatefulset(ctx conte
 		return nil, err
 	}
 
+	if !volumeClaimTemplatesEqual(st.Spec.VolumeClaimTemplates, est.Spec.VolumeClaimTemplates) {
+		msg := fmt.Sprintf("compute group %s storage template is immutable after creation; modifying BE file_cache_path or persistent volume settings requires recreating the compute group", cg.UniqueId)
+		klog.Errorf("disaggregatedComputeGroupsController reconcileStatefulset immutable storage template changed, namespace=%s name=%s, err=%s", st.Namespace, st.Name, msg)
+		return &sc.Event{Type: sc.EventWarning, Reason: sc.CGStorageTemplateImmutable, Message: msg}, errors.New(msg)
+	}
+
 	err := dcgs.preApplyStatefulSet(ctx, st, &est, cluster, cg)
 	if err != nil {
 		klog.Errorf("disaggregatedComputeGroupsController reconcileStatefulset preApplyStatefulSet namespace=%s name=%s failed, err=%s", st.Namespace, st.Name, err.Error())
@@ -280,6 +288,45 @@ func (dcgs *DisaggregatedComputeGroupsController) reconcileStatefulset(ctx conte
 	}
 
 	return nil, nil
+}
+
+func volumeClaimTemplatesEqual(new, old []corev1.PersistentVolumeClaim) bool {
+	if len(new) != len(old) {
+		return false
+	}
+
+	normalizedNew := make([]corev1.PersistentVolumeClaim, len(new))
+	normalizedOld := make([]corev1.PersistentVolumeClaim, len(old))
+	for i := range new {
+		normalizedNew[i] = normalizeVolumeClaimTemplate(new[i])
+		normalizedOld[i] = normalizeVolumeClaimTemplate(old[i])
+	}
+
+	return equality.Semantic.DeepEqual(normalizedNew, normalizedOld)
+}
+
+func normalizeVolumeClaimTemplate(pvc corev1.PersistentVolumeClaim) corev1.PersistentVolumeClaim {
+	pvc.ObjectMeta = metav1.ObjectMeta{
+		Name:        pvc.Name,
+		Labels:      normalizeStringMap(pvc.Labels),
+		Annotations: normalizeStringMap(pvc.Annotations),
+	}
+	if pvc.Spec.VolumeMode == nil {
+		volumeMode := corev1.PersistentVolumeFilesystem
+		pvc.Spec.VolumeMode = &volumeMode
+	}
+	return pvc
+}
+
+func normalizeStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	normalized := make(map[string]string, len(m))
+	for k, v := range m {
+		normalized[k] = v
+	}
+	return normalized
 }
 
 // initial compute group status before sync resources. status changing with sync steps, and generate the last status by classify pods.

--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller_test.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller_test.go
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package computegroups
+
+import (
+	"context"
+	"testing"
+
+	sc "github.com/apache/doris-operator/pkg/controller/sub_controller"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileStatefulsetRejectsStorageTemplateChange(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme failed: %v", err)
+	}
+
+	ddc := newTestDDC()
+	cg := newTestCG("cg1")
+	existing := newTestStatefulSet(ddc.Namespace, ddc.GetCGStatefulsetName(cg), "100Gi")
+	desired := newTestStatefulSet(ddc.Namespace, ddc.GetCGStatefulsetName(cg), "200Gi")
+	dcgs := &DisaggregatedComputeGroupsController{}
+	dcgs.K8sclient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	event, err := dcgs.reconcileStatefulset(context.Background(), desired, ddc, cg)
+	if err == nil {
+		t.Fatal("reconcileStatefulset expected immutable storage template error")
+	}
+	if event == nil {
+		t.Fatal("reconcileStatefulset expected event")
+	}
+	if event.Reason != sc.CGStorageTemplateImmutable {
+		t.Fatalf("event reason = %s, want %s", event.Reason, sc.CGStorageTemplateImmutable)
+	}
+}
+
+func TestVolumeClaimTemplatesEqualIgnoresDefaultVolumeMode(t *testing.T) {
+	withDefault := newTestStatefulSet("default", "doris-cg1", "100Gi").Spec.VolumeClaimTemplates
+	withoutDefault := newTestStatefulSet("default", "doris-cg1", "100Gi").Spec.VolumeClaimTemplates
+	volumeMode := corev1.PersistentVolumeFilesystem
+	withDefault[0].Spec.VolumeMode = &volumeMode
+
+	if !volumeClaimTemplatesEqual(withoutDefault, withDefault) {
+		t.Fatal("volumeClaimTemplatesEqual should ignore default filesystem volume mode")
+	}
+}
+
+func newTestStatefulSet(namespace, name, storage string) *appv1.StatefulSet {
+	return &appv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "be-storage0",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse(storage),
+						},
+					},
+				},
+			}},
+		},
+	}
+}

--- a/pkg/controller/sub_controller/events.go
+++ b/pkg/controller/sub_controller/events.go
@@ -62,6 +62,7 @@ var (
 	CGUniqueIdentifierNotMatchRegex EventReason = "CGUniqueIdentifierNotMatchRegex"
 	CGCreateResourceFailed          EventReason = "CGCreateResourceFailed"
 	CGApplyResourceFailed           EventReason = "CGApplyResourceFailed"
+	CGStorageTemplateImmutable      EventReason = "CGStorageTemplateImmutable"
 	CGStatefulsetDeleteFailed       EventReason = "CGStatefulsetDeleteFailed"
 	CGServiceDeleteFailed           EventReason = "CGServiceDeleteFailed"
 	ConfigMapPathRepeated           EventReason = "ConfigMapPathRepeated"


### PR DESCRIPTION
## Motivation
Changing BE file cache paths or persistent volume settings after a DDC compute group has been created changes the generated StatefulSet volume claim templates. Kubernetes does not allow updating StatefulSet volumeClaimTemplates in place, so the reconcile currently fails later with a low-level immutable field error. This makes the failure hard to understand and can look like a generic StatefulSet apply problem.

This change detects the storage template change before applying the StatefulSet and returns a clear operator event telling users to recreate the compute group for this kind of storage layout change.

## Summary
- reject DDC compute group storage template changes before applying StatefulSet
- return a clear CGStorageTemplateImmutable event for file_cache_path / persistent volume changes
- add unit coverage for immutable storage template detection and default volumeMode normalization

## Tests
- go test ./pkg/controller/sub_controller/disaggregated_cluster/computegroups

## Notes
- go test ./pkg/controller/sub_controller/... currently requires local envtest binaries; this environment is missing bin/k8s/1.26.1-darwin-arm64/etcd.