### PR TITLE
fix: FE endpoint address JSON tag

### DIFF
--- a/api/doris/v1/types.go
+++ b/api/doris/v1/types.go
@@ -149,7 +149,7 @@ type FeAddress struct {
 // Endpoints describe the address outside k8s.
 type Endpoints struct {
 	//the ip or domain array.
-	Address []string `json:":address,omitempty"`
+	Address []string `json:"address,omitempty"`
 
 	// the fe port that for query. the field `query_port` defines in fe config.
 	Port int `json:"port,omitempty"`

--- a/config/crd/bases/crds.yaml
+++ b/config/crd/bases/crds.yaml
@@ -1417,7 +1417,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -3531,7 +3531,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -6274,7 +6274,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -8394,7 +8394,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string

--- a/config/crd/bases/doris.apache.com_dorisclusters.yaml
+++ b/config/crd/bases/doris.apache.com_dorisclusters.yaml
@@ -1417,7 +1417,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -3531,7 +3531,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -6274,7 +6274,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -8394,7 +8394,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string

--- a/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
+++ b/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
@@ -1417,7 +1417,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -3531,7 +3531,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -6274,7 +6274,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -8394,7 +8394,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string

--- a/helm-charts/doris-operator/crds/doris.apache.com_dorisclusters.yaml
+++ b/helm-charts/doris-operator/crds/doris.apache.com_dorisclusters.yaml
@@ -1417,7 +1417,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -3531,7 +3531,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -6274,7 +6274,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string
@@ -8394,7 +8394,7 @@ spec:
                         description: the fe addresses if not deploy by crd, user can
                           use k8s deploy fe observer.
                         properties:
-                          :address:
+                          address:
                             description: the ip or domain array.
                             items:
                               type: string


### PR DESCRIPTION
## Summary
- Fix the FE endpoint address JSON tag from the invalid `:address` property to `address`.
- Regenerate DorisCluster CRDs so the schema no longer exposes `:address:` under `feAddress.endpoints`.

## Compatibility
Existing CRs that use the erroneous `:address` key should be migrated to `address`. The old key was produced by a typo in the Go json tag and caused generated CRD schemas to expose an invalid property name.

## Testing
- `make manifests`
- `go test ./api/doris/v1`