### PR TITLE
fix: reject invalid disaggregated FE replicas

### DIFF
--- a/api/disaggregated/v1/disaggregatedcluster_webhook.go
+++ b/api/disaggregated/v1/disaggregatedcluster_webhook.go
@@ -19,6 +19,8 @@ package v1
 
 import (
 	"context"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,16 +53,14 @@ var _ webhook.CustomValidator = &DorisDisaggregatedCluster{}
 func (ddc *DorisDisaggregatedCluster) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	klog.Info("validate create", "name", ddc.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
-	return nil, nil
+	return nil, ddc.validateFEReplicas()
 }
 
 // ValidateUpdate implements webhook.Validator so a unnamedwatches will be registered for the type
 func (ddc *DorisDisaggregatedCluster) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	klog.Info("validate update", "name", ddc.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
-	return nil, nil
+	return nil, ddc.validateFEReplicas()
 }
 
 // ValidateDelete implements webhook.Validator so a unnamedwatches will be registered for the type
@@ -69,4 +69,14 @@ func (ddc *DorisDisaggregatedCluster) ValidateDelete(ctx context.Context, obj ru
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil, nil
+}
+
+func (ddc *DorisDisaggregatedCluster) validateFEReplicas() error {
+	if ddc.Spec.FeSpec.Replicas == nil {
+		return nil
+	}
+	if *ddc.Spec.FeSpec.Replicas < ddc.GetElectionNumber() {
+		return fmt.Errorf("'FeSpec.Replicas' error: the number of FeSpec.Replicas should greater than or equal to FeSpec.ElectionNumber")
+	}
+	return nil
 }

--- a/api/disaggregated/v1/disaggregatedcluster_webhook_test.go
+++ b/api/disaggregated/v1/disaggregatedcluster_webhook_test.go
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDorisDisaggregatedClusterValidateFEReplicas(t *testing.T) {
+	replicas := int32(1)
+	electionNumber := int32(2)
+	ddc := &DorisDisaggregatedCluster{
+		Spec: DorisDisaggregatedClusterSpec{
+			FeSpec: FeSpec{
+				ElectionNumber: &electionNumber,
+				CommonSpec: CommonSpec{
+					Replicas: &replicas,
+				},
+			},
+		},
+	}
+
+	if _, err := ddc.ValidateCreate(context.Background(), ddc); err == nil {
+		t.Fatal("expected create validation to reject replicas smaller than electionNumber")
+	}
+	if _, err := ddc.ValidateUpdate(context.Background(), ddc, ddc); err == nil {
+		t.Fatal("expected update validation to reject replicas smaller than electionNumber")
+	}
+
+	replicas = 2
+	if _, err := ddc.ValidateCreate(context.Background(), ddc); err != nil {
+		t.Fatalf("expected valid create to pass, got %v", err)
+	}
+	if _, err := ddc.ValidateUpdate(context.Background(), ddc, ddc); err != nil {
+		t.Fatalf("expected valid update to pass, got %v", err)
+	}
+}


### PR DESCRIPTION
## Motivation

For a DorisDisaggregatedCluster, FE replicas must not be smaller than electionNumber. Today an invalid update such as reducing FE replicas from 2 to 1 while electionNumber is 2 can be accepted first and only corrected later during reconciliation. That delayed correction can still patch the FE StatefulSet and trigger unnecessary FE restart behavior.

## Changes

- Validate FE replicas on DorisDisaggregatedCluster create and update.
- Reject specs where `feSpec.replicas < feSpec.electionNumber`.
- Add unit coverage for invalid and valid FE replica settings.

## Tests

- `go test ./api/disaggregated/v1`