### PR TITLE
improve: reject admin management user in webhooks

### DIFF
--- a/api/disaggregated/v1/disaggregatedcluster_webhook.go
+++ b/api/disaggregated/v1/disaggregatedcluster_webhook.go
@@ -19,11 +19,14 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"strings"
 )
 
 // log is for logging in this package.
@@ -51,7 +54,10 @@ var _ webhook.CustomValidator = &DorisDisaggregatedCluster{}
 func (ddc *DorisDisaggregatedCluster) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	klog.Info("validate create", "name", ddc.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
+	if errs := ddc.validateManagementUser(); len(errs) != 0 {
+		return nil, kerrors.NewAggregate(errs)
+	}
+
 	return nil, nil
 }
 
@@ -59,7 +65,10 @@ func (ddc *DorisDisaggregatedCluster) ValidateCreate(ctx context.Context, obj ru
 func (ddc *DorisDisaggregatedCluster) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	klog.Info("validate update", "name", ddc.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	if errs := ddc.validateManagementUser(); len(errs) != 0 {
+		return nil, kerrors.NewAggregate(errs)
+	}
+
 	return nil, nil
 }
 
@@ -69,4 +78,12 @@ func (ddc *DorisDisaggregatedCluster) ValidateDelete(ctx context.Context, obj ru
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil, nil
+}
+
+func (ddc *DorisDisaggregatedCluster) validateManagementUser() []error {
+	if ddc.Spec.AdminUser == nil || !strings.EqualFold(ddc.Spec.AdminUser.Name, "admin") {
+		return nil
+	}
+
+	return []error{fmt.Errorf("'adminUser.name' error: admin is not supported as management user, use root or a dedicated user with NODE_PRIV")}
 }

--- a/api/disaggregated/v1/disaggregatedcluster_webhook_test.go
+++ b/api/disaggregated/v1/disaggregatedcluster_webhook_test.go
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDorisDisaggregatedClusterRejectsAdminManagementUser(t *testing.T) {
+	cluster := &DorisDisaggregatedCluster{
+		Spec: DorisDisaggregatedClusterSpec{
+			AdminUser: &AdminUser{Name: "admin"},
+		},
+	}
+
+	if _, err := cluster.ValidateCreate(context.Background(), cluster); err == nil {
+		t.Fatal("expected admin management user to be rejected on create")
+	}
+
+	if _, err := cluster.ValidateUpdate(context.Background(), cluster, cluster); err == nil {
+		t.Fatal("expected admin management user to be rejected on update")
+	}
+}
+
+func TestDorisDisaggregatedClusterAllowsNonAdminManagementUser(t *testing.T) {
+	cluster := &DorisDisaggregatedCluster{
+		Spec: DorisDisaggregatedClusterSpec{
+			AdminUser: &AdminUser{Name: "doris_operator"},
+		},
+	}
+
+	if _, err := cluster.ValidateCreate(context.Background(), cluster); err != nil {
+		t.Fatalf("expected non-admin management user to be allowed on create: %v", err)
+	}
+
+	if _, err := cluster.ValidateUpdate(context.Background(), cluster, cluster); err != nil {
+		t.Fatalf("expected non-admin management user to be allowed on update: %v", err)
+	}
+}

--- a/api/doris/v1/doriscluster_webhook.go
+++ b/api/doris/v1/doriscluster_webhook.go
@@ -42,6 +42,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"strings"
 )
 
 // log is for logging in this package.
@@ -71,7 +72,10 @@ var _ webhook.CustomValidator = &DorisCluster{}
 func (r *DorisCluster) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	klog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
+	if errs := r.validateManagementUser(); len(errs) != 0 {
+		return nil, kerrors.NewAggregate(errs)
+	}
+
 	return nil, nil
 }
 
@@ -79,6 +83,7 @@ func (r *DorisCluster) ValidateCreate(ctx context.Context, obj runtime.Object) (
 func (r *DorisCluster) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	klog.Info("validate update", "name", r.Name)
 	var errors []error
+	errors = append(errors, r.validateManagementUser()...)
 	// fe FeSpec.Replicas must greater than or equal to FeSpec.ElectionNumber
 	if *r.Spec.FeSpec.Replicas < r.GetElectionNumber() {
 		errors = append(errors, fmt.Errorf("'FeSpec.Replicas' error: the number of FeSpec.Replicas should greater than or equal to FeSpec.ElectionNumber"))
@@ -97,4 +102,12 @@ func (r *DorisCluster) ValidateDelete(ctx context.Context, obj runtime.Object) (
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil, nil
+}
+
+func (r *DorisCluster) validateManagementUser() []error {
+	if r.Spec.AdminUser == nil || !strings.EqualFold(r.Spec.AdminUser.Name, "admin") {
+		return nil
+	}
+
+	return []error{fmt.Errorf("'adminUser.name' error: admin is not supported as management user, use root or a dedicated user with NODE_PRIV")}
 }

--- a/api/doris/v1/doriscluster_webhook_test.go
+++ b/api/doris/v1/doriscluster_webhook_test.go
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDorisClusterRejectsAdminManagementUser(t *testing.T) {
+	cluster := &DorisCluster{
+		Spec: DorisClusterSpec{
+			AdminUser: &AdminUser{Name: "admin"},
+		},
+	}
+
+	if _, err := cluster.ValidateCreate(context.Background(), cluster); err == nil {
+		t.Fatal("expected admin management user to be rejected on create")
+	}
+
+	replicas := int32(3)
+	cluster.Spec.FeSpec = &FeSpec{BaseSpec: BaseSpec{Replicas: &replicas}}
+	if _, err := cluster.ValidateUpdate(context.Background(), cluster, cluster); err == nil {
+		t.Fatal("expected admin management user to be rejected on update")
+	}
+}
+
+func TestDorisClusterAllowsNonAdminManagementUser(t *testing.T) {
+	cluster := &DorisCluster{
+		Spec: DorisClusterSpec{
+			AdminUser: &AdminUser{Name: "doris_operator"},
+		},
+	}
+
+	if _, err := cluster.ValidateCreate(context.Background(), cluster); err != nil {
+		t.Fatalf("expected non-admin management user to be allowed on create: %v", err)
+	}
+
+	replicas := int32(3)
+	cluster.Spec.FeSpec = &FeSpec{BaseSpec: BaseSpec{Replicas: &replicas}}
+	if _, err := cluster.ValidateUpdate(context.Background(), cluster, cluster); err != nil {
+		t.Fatalf("expected non-admin management user to be allowed on update: %v", err)
+	}
+}


### PR DESCRIPTION
## Motivation

Using the built-in `admin` account as the operator management user can leave Doris nodes created in Kubernetes but not successfully registered in FE metadata. The failure is only discovered later through symptoms such as `show backends` returning fewer BE nodes than the requested replicas. Rejecting this unsupported configuration in admission gives users an immediate and actionable error.

## Changes

- Reject `spec.adminUser.name=admin` for `DorisCluster` on create and update.
- Reject `spec.adminUser.name=admin` for `DorisDisaggregatedCluster` on create and update.
- Keep `root` and dedicated management users with `NODE_PRIV` allowed.
- Add focused webhook tests for both resource types.

## Tests

- `go test ./api/disaggregated/v1 -run 'TestDorisDisaggregatedCluster.*ManagementUser'`\n- `go test ./api/doris/v1 -run 'TestDorisCluster.*ManagementUser'`