### PR TITLE
fix：DDC meta service health aggregation

### DIFF
--- a/pkg/controller/disaggregated_cluster_controller.go
+++ b/pkg/controller/disaggregated_cluster_controller.go
@@ -271,9 +271,9 @@ func (dc *DisaggregatedClusterReconciler) reorganizeStatus(ddc *dv1.DorisDisaggr
 
 	ddc.Status.ObservedGeneration = ddc.Generation
 	ddc.Status.ClusterHealth.Health = dv1.Green
-	if ddc.Status.FEStatus.AvailableStatus != dv1.Available || ddc.Status.ClusterHealth.CGAvailableCount <= (ddc.Status.ClusterHealth.CGCount/2) {
+	if ddc.Status.MetaServiceStatus.AvailableStatus != dv1.Available || ddc.Status.FEStatus.AvailableStatus != dv1.Available || ddc.Status.ClusterHealth.CGAvailableCount <= (ddc.Status.ClusterHealth.CGCount/2) {
 		ddc.Status.ClusterHealth.Health = dv1.Red
-	} else if ddc.Status.FEStatus.Phase != dv1.Ready || ddc.Status.ClusterHealth.CGAvailableCount < ddc.Status.ClusterHealth.CGCount {
+	} else if ddc.Status.MetaServiceStatus.Phase != dv1.Ready || ddc.Status.FEStatus.Phase != dv1.Ready || ddc.Status.ClusterHealth.CGAvailableCount < ddc.Status.ClusterHealth.CGCount {
 		ddc.Status.ClusterHealth.Health = dv1.Yellow
 	}
 

--- a/pkg/controller/disaggregated_cluster_controller_test.go
+++ b/pkg/controller/disaggregated_cluster_controller_test.go
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	dv1 "github.com/apache/doris-operator/api/disaggregated/v1"
+	sc "github.com/apache/doris-operator/pkg/controller/sub_controller"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type fakeDisaggregatedSubController struct {
+	name string
+}
+
+func (f fakeDisaggregatedSubController) Sync(ctx context.Context, obj client.Object) error {
+	return nil
+}
+
+func (f fakeDisaggregatedSubController) ClearResources(ctx context.Context, obj client.Object) (bool, error) {
+	return true, nil
+}
+
+func (f fakeDisaggregatedSubController) GetControllerName() string {
+	return f.name
+}
+
+func (f fakeDisaggregatedSubController) UpdateComponentStatus(obj client.Object) error {
+	return nil
+}
+
+var _ sc.DisaggregatedSubController = fakeDisaggregatedSubController{}
+
+func TestReorganizeStatusConsidersMetaServiceHealth(t *testing.T) {
+	tests := []struct {
+		name              string
+		metaServiceStatus dv1.MetaServiceStatus
+		wantHealth        dv1.Health
+	}{
+		{
+			name: "meta service not fully ready makes cluster yellow",
+			metaServiceStatus: dv1.MetaServiceStatus{
+				AvailableStatus: dv1.Available,
+				Phase:           dv1.Reconciling,
+			},
+			wantHealth: dv1.Yellow,
+		},
+		{
+			name: "meta service unavailable makes cluster red",
+			metaServiceStatus: dv1.MetaServiceStatus{
+				AvailableStatus: dv1.UnAvailable,
+				Phase:           dv1.Reconciling,
+			},
+			wantHealth: dv1.Red,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddc := &dv1.DorisDisaggregatedCluster{}
+			ddc.Status.MetaServiceStatus = tt.metaServiceStatus
+			ddc.Status.FEStatus.AvailableStatus = dv1.Available
+			ddc.Status.FEStatus.Phase = dv1.Ready
+			ddc.Status.ClusterHealth.CGCount = 1
+			ddc.Status.ClusterHealth.CGAvailableCount = 1
+
+			reconciler := &DisaggregatedClusterReconciler{
+				Scs: map[string]sc.DisaggregatedSubController{
+					"fake": fakeDisaggregatedSubController{name: "fake"},
+				},
+			}
+
+			_, err := reconciler.reorganizeStatus(ddc)
+			if err != nil {
+				t.Fatalf("reorganizeStatus returned error: %v", err)
+			}
+			if ddc.Status.ClusterHealth.Health != tt.wantHealth {
+				t.Fatalf("health = %s, want %s", ddc.Status.ClusterHealth.Health, tt.wantHealth)
+			}
+		})
+	}
+}

--- a/pkg/controller/sub_controller/disaggregated_cluster/metaservice/controller.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/metaservice/controller.go
@@ -135,6 +135,8 @@ func (dms *DisaggregatedMSController) UpdateComponentStatus(obj client.Object) e
 	}
 	if availableReplicas == msReplicas && allUpdated {
 		ddc.Status.MetaServiceStatus.Phase = v1.Ready
+	} else {
+		ddc.Status.MetaServiceStatus.Phase = v1.Reconciling
 	}
 
 	return nil

--- a/pkg/controller/sub_controller/disaggregated_cluster/metaservice/controller_test.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/metaservice/controller_test.go
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metaservice
+
+import (
+	"testing"
+
+	dv1 "github.com/apache/doris-operator/api/disaggregated/v1"
+	"github.com/apache/doris-operator/pkg/controller/sub_controller"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestUpdateComponentStatusDowngradesMetaServicePhase(t *testing.T) {
+	replicas := int32(2)
+	ddc := &dv1.DorisDisaggregatedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ddc",
+			Namespace: "default",
+		},
+		Spec: dv1.DorisDisaggregatedClusterSpec{
+			MetaService: dv1.MetaService{
+				CommonSpec: dv1.CommonSpec{
+					Replicas: &replicas,
+				},
+			},
+		},
+		Status: dv1.DorisDisaggregatedClusterStatus{
+			MetaServiceStatus: dv1.MetaServiceStatus{
+				AvailableStatus: dv1.Available,
+				Phase:           dv1.Ready,
+			},
+		},
+	}
+
+	controller := &DisaggregatedMSController{}
+	selector := controller.newMSPodsSelector(ddc.Name)
+	sts := &appv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ddc.GetMSStatefulsetName(),
+			Namespace: ddc.Namespace,
+		},
+		Status: appv1.StatefulSetStatus{
+			UpdateRevision: "revision-1",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ddc.GetMSStatefulsetName() + "-0",
+			Namespace: ddc.Namespace,
+			Labels:    selector,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := appv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	controller.DisaggregatedSubDefaultController = sub_controller.DisaggregatedSubDefaultController{
+		K8sclient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts, pod).Build(),
+	}
+
+	if err := controller.UpdateComponentStatus(ddc); err != nil {
+		t.Fatalf("UpdateComponentStatus returned error: %v", err)
+	}
+	if ddc.Status.MetaServiceStatus.AvailableStatus != dv1.Available {
+		t.Fatalf("available status = %s, want %s", ddc.Status.MetaServiceStatus.AvailableStatus, dv1.Available)
+	}
+	if ddc.Status.MetaServiceStatus.Phase != dv1.Reconciling {
+		t.Fatalf("phase = %s, want %s", ddc.Status.MetaServiceStatus.Phase, dv1.Reconciling)
+	}
+}


### PR DESCRIPTION
### Motivation

`kubectl get ddc` can still show cluster health as `green` after one MetaService pod is down. The DDC cluster health aggregation currently only considers FE availability and compute group availability, so MetaService degradation is not reflected in `status.clusterHealth.health`.

There is also a stale status path: once MetaService `Phase` becomes `Ready`, `UpdateComponentStatus` does not downgrade it when the available MetaService replicas drop below the desired replicas.

### Changes

- Downgrade DDC MetaService `Phase` to `Reconciling` when not all desired MetaService replicas are ready on the latest StatefulSet revision.
- Include DDC MetaService availability and phase in cluster health aggregation:
  - MetaService unavailable -> `red`
  - MetaService available but not fully ready -> `yellow`
- Add unit tests for MetaService phase downgrade and DDC cluster health aggregation.

### Tests

```bash
go test ./pkg/controller/sub_controller/disaggregated_cluster/metaservice
go test ./pkg/controller -run TestReorganizeStatusConsidersMetaServiceHealth
go test ./pkg/controller/sub_controller/disaggregated_cluster/...
```
