### PR TITLE
[fix] Add FoundationDB chart retention guardrails

### DIFF
--- a/helm-charts/doris-foundationdb/README.md
+++ b/helm-charts/doris-foundationdb/README.md
@@ -23,3 +23,21 @@ The foundationdb cluster is a practice for doris.
    ```Bash
    $ helm install doris-foundationdb selectdb/doris-foundationdb
    ```
+
+## Data safety notes
+
+- Keep FoundationDB in a dedicated Helm or Flux release. Doris configMap or compute-group changes should not rebuild the FoundationDB release.
+- This chart keeps the `FoundationDBCluster` resource by default with `helm.sh/resource-policy: keep` to reduce accidental metadata loss during Helm uninstall or release replacement.
+- Use a `StorageClass` with `reclaimPolicy=Retain` for FoundationDB metadata volumes. The PVC template controls claim shape, but the `StorageClass` controls PV retention behavior.
+
+Example values:
+
+```yaml
+keepClusterResource: true
+volumeClaimTemplate:
+  spec:
+    storageClassName: retain-sc
+    resources:
+      requests:
+        storage: 50G
+```

--- a/helm-charts/doris-foundationdb/templates/foundationdb.yaml
+++ b/helm-charts/doris-foundationdb/templates/foundationdb.yaml
@@ -19,6 +19,10 @@ apiVersion: apps.foundationdb.org/v1beta2
 kind: FoundationDBCluster
 metadata:
   name: {{ include "foundationdb.clusterName" . }}
+  {{- if .Values.keepClusterResource }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   databaseConfiguration:
     redundancy_mode: {{ template "foundationdb.redundancyMode" }}

--- a/helm-charts/doris-foundationdb/values.yaml
+++ b/helm-charts/doris-foundationdb/values.yaml
@@ -1,6 +1,11 @@
 # specify the foundationdb cluster name
 name: test-cluster
 
+# Keep the FoundationDBCluster object during Helm uninstall or release
+# replacement so that unrelated Doris chart changes do not implicitly tear
+# down the metadata cluster.
+keepClusterResource: true
+
 #specify the data replicas. enum: single, double, triple
 redundancy_mode: "double"
 
@@ -34,8 +39,11 @@ resources:
 
 # VolumeClaimTemplate allows customizing the persistent volume claim for the pod.
 # this config reference the kubernetes doc about statefulset volumeClaimTemplate: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+# Production metadata volumes should use a StorageClass with
+# reclaimPolicy=Retain. PVC template fields alone do not control PV retention.
 volumeClaimTemplate:
   spec:
+    # storageClassName: retain-sc
     resources:
       requests:
         storage: 50G


### PR DESCRIPTION
## Summary

- keep the `FoundationDBCluster` resource by default in the `doris-foundationdb` chart with `helm.sh/resource-policy: keep`
- document that FoundationDB should be managed in its own Helm or Flux release, separate from Doris config-only rollouts
- document that production metadata volumes should use a `StorageClass` with `reclaimPolicy=Retain`

## Motivation

FoundationDB stores metadata for storage-compute decoupled Doris deployments. A Doris config-only change, such as updating BE config maps or compute-group settings, should not implicitly tear down the FoundationDB metadata cluster.

This change adds chart-level guardrails to reduce accidental metadata loss when Helm would otherwise delete the `FoundationDBCluster` resource during uninstall, upgrade, or rollback workflows.

## Important behavior

`helm.sh/resource-policy: keep` prevents Helm from deleting the `FoundationDBCluster` resource, but the retained resource becomes orphaned from the Helm release. Operators must account for that behavior during uninstall, reinstall, or `helm install --replace` workflows.

This guardrail does not replace deployment-level lifecycle separation. FoundationDB should still be deployed and upgraded independently from Doris config-only changes.

This guardrail also does not control PV reclaim behavior. Production deployments should explicitly configure a `StorageClass` with `reclaimPolicy=Retain` for FoundationDB metadata volumes.
