### PR TITLE
fix: ignore runtime PVC template fields

### DIFF
--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller.go
@@ -334,11 +334,13 @@ func volumeClaimTemplatesEqual(new, old []corev1.PersistentVolumeClaim) bool {
 }
 
 func normalizeVolumeClaimTemplate(pvc corev1.PersistentVolumeClaim) corev1.PersistentVolumeClaim {
+	pvc.TypeMeta = metav1.TypeMeta{}
 	pvc.ObjectMeta = metav1.ObjectMeta{
 		Name:        pvc.Name,
 		Labels:      normalizeStringMap(pvc.Labels),
 		Annotations: normalizeStringMap(pvc.Annotations),
 	}
+	pvc.Status = corev1.PersistentVolumeClaimStatus{}
 	if pvc.Spec.VolumeMode == nil {
 		volumeMode := corev1.PersistentVolumeFilesystem
 		pvc.Spec.VolumeMode = &volumeMode

--- a/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller_test.go
+++ b/pkg/controller/sub_controller/disaggregated_cluster/computegroups/controller_test.go
@@ -82,6 +82,21 @@ func TestVolumeClaimTemplatesEqualIgnoresDefaultVolumeMode(t *testing.T) {
 	}
 }
 
+func TestVolumeClaimTemplatesEqualIgnoresRuntimeFields(t *testing.T) {
+	desired := newTestStatefulSet("default", "doris-cg1", "100Gi").Spec.VolumeClaimTemplates
+	existing := newTestStatefulSet("default", "doris-cg1", "100Gi").Spec.VolumeClaimTemplates
+
+	existing[0].TypeMeta = metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "PersistentVolumeClaim",
+	}
+	existing[0].Status.Phase = corev1.ClaimPending
+
+	if !volumeClaimTemplatesEqual(desired, existing) {
+		t.Fatal("volumeClaimTemplatesEqual should ignore runtime-only pvc template fields")
+	}
+}
+
 func newTestStatefulSet(namespace, name, storage string) *appv1.StatefulSet {
 	return &appv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary
- ignore TypeMeta and Status when comparing compute group PVC templates
- add coverage for runtime-only PVC template fields

## Tests
- go test ./pkg/controller/sub_controller/disaggregated_cluster/computegroups