### PR TITLE
fix: run license check safely for fork PRs

### DIFF
--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -17,21 +17,15 @@
 #
 ---
 name: License Check
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   license-check:
     name: "License Check"
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v3
-      - name: Checkout ${{ github.ref }} ( ${{ github.event.pull_request.head.sha }} )
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Check License
         uses: apache/skywalking-eyes@v0.2.0
         env:


### PR DESCRIPTION
## Summary

- run the license workflow on pull_request instead of pull_request_target
- upgrade checkout to actions/checkout@v4
- use the default low-privilege fork PR checkout instead of opting into unsafe checkout

## Validation

- parsed .github/workflows/license-eyes.yml successfully as YAML
- git diff --check

## Context

The existing pull_request_target job now fails before the license scan because actions/checkout refuses to check out fork code in a privileged workflow. This PR itself may still show that legacy check failure because pull_request_target workflows are loaded from the default branch; the new workflow takes effect after merge.